### PR TITLE
Allow sorting on the TSDB reader

### DIFF
--- a/convert/convert.go
+++ b/convert/convert.go
@@ -100,10 +100,7 @@ func newTsdbRowReader(ctx context.Context, mint, maxt, colDuration int64, blks [
 		b.AddLabelNameColumn(lblns...)
 	}
 
-	cseriesSet, err := NewMergeChunkSeriesSet(seriesSets, compareFunc, storage.NewConcatenatingChunkSeriesMerger())
-	if err != nil {
-		return nil, fmt.Errorf("unable to create MergeChunkSeriesSet: %s", err)
-	}
+	cseriesSet := NewMergeChunkSeriesSet(seriesSets, compareFunc, storage.NewConcatenatingChunkSeriesMerger())
 
 	s, err := b.Build()
 	if err != nil {

--- a/convert/convert.go
+++ b/convert/convert.go
@@ -133,7 +133,6 @@ func sortedPostings(ctx context.Context, indexr tsdb.IndexReader, sortedLabels .
 	}
 	series := make([]s, 0, 128)
 
-	// Fetch all the series only once.
 	lb := labels.NewScratchBuilder(10)
 	for p.Next() {
 		lb.Reset()
@@ -142,7 +141,7 @@ func sortedPostings(ctx context.Context, indexr tsdb.IndexReader, sortedLabels .
 			return index.ErrPostings(fmt.Errorf("expand series: %w", err))
 		}
 
-		series = append(series, s{labels: lb.Labels(), ref: p.At()})
+		series = append(series, s{labels: lb.Labels().MatchLabels(true, sortedLabels...), ref: p.At()})
 	}
 	if err := p.Err(); err != nil {
 		return index.ErrPostings(fmt.Errorf("expand postings: %w", err))

--- a/convert/convert.go
+++ b/convert/convert.go
@@ -146,7 +146,6 @@ func sortedPostings(ctx context.Context, indexr tsdb.IndexReader, sortedLabels .
 	}
 	if err := p.Err(); err != nil {
 		return index.ErrPostings(fmt.Errorf("expand postings: %w", err))
-
 	}
 
 	slices.SortFunc(series, func(a, b s) int {

--- a/convert/convert_test.go
+++ b/convert/convert_test.go
@@ -215,6 +215,7 @@ func Test_SortedLabels(t *testing.T) {
 		_, err := app.Append(0, lbls, 10, float64(i))
 		require.NoError(t, err)
 		_, err = app2.Append(0, lbls, 11, float64(i+1))
+		require.NoError(t, err)
 		totalSeries++
 	}
 

--- a/convert/merge.go
+++ b/convert/merge.go
@@ -21,7 +21,7 @@ import (
 	"github.com/prometheus/prometheus/util/annotations"
 )
 
-func NewMergeChunkSeriesSet(sets []storage.ChunkSeriesSet, compare func(a, b labels.Labels) int, mergeFunc storage.VerticalChunkSeriesMergeFunc) (storage.ChunkSeriesSet, error) {
+func NewMergeChunkSeriesSet(sets []storage.ChunkSeriesSet, compare func(a, b labels.Labels) int, mergeFunc storage.VerticalChunkSeriesMergeFunc) storage.ChunkSeriesSet {
 	h := heapChunkSeries{
 		heap:    make([]storage.ChunkSeriesSet, 0, len(sets)),
 		compare: compare,
@@ -34,13 +34,14 @@ func NewMergeChunkSeriesSet(sets []storage.ChunkSeriesSet, compare func(a, b lab
 			heap.Push(&h, set)
 		}
 		if err := set.Err(); err != nil {
-			return nil, err
+			return &mergeChunkSeriesSet{err: err}
 		}
 	}
+
 	return &mergeChunkSeriesSet{
 		h:         h,
 		mergeFunc: mergeFunc,
-	}, nil
+	}
 }
 
 type mergeChunkSeriesSet struct {

--- a/convert/merge.go
+++ b/convert/merge.go
@@ -1,0 +1,112 @@
+package convert
+
+import (
+	"container/heap"
+
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/storage"
+	"github.com/prometheus/prometheus/util/annotations"
+)
+
+func NewMergeChunkSeriesSet(sets []storage.ChunkSeriesSet, compare func(a, b labels.Labels) int, mergeFunc storage.VerticalChunkSeriesMergeFunc) (storage.ChunkSeriesSet, error) {
+	h := heapChunkSeries{
+		heap:    make([]storage.ChunkSeriesSet, 0, len(sets)),
+		compare: compare,
+	}
+	for _, set := range sets {
+		if set == nil {
+			continue
+		}
+		if set.Next() {
+			heap.Push(&h, set)
+		}
+		if err := set.Err(); err != nil {
+			return nil, err
+		}
+	}
+	return &mergeChunkSeriesSet{
+		h:         h,
+		mergeFunc: mergeFunc,
+	}, nil
+}
+
+type mergeChunkSeriesSet struct {
+	h           heapChunkSeries
+	mergeFunc   storage.VerticalChunkSeriesMergeFunc
+	currentSets []storage.ChunkSeriesSet
+
+	err error
+}
+
+func (m *mergeChunkSeriesSet) Next() bool {
+	for _, set := range m.currentSets {
+		if set == nil {
+			continue
+		}
+		if set.Next() {
+			heap.Push(&m.h, set)
+		}
+		if err := set.Err(); err != nil {
+			m.err = err
+			break
+		}
+	}
+
+	if len(m.h.heap) == 0 {
+		return false
+	}
+
+	m.currentSets = m.currentSets[:0]
+	currentLabels := m.h.heap[0].At().Labels()
+
+	for len(m.h.heap) > 0 && labels.Equal(m.h.heap[0].At().Labels(), currentLabels) {
+		m.currentSets = append(m.currentSets, heap.Pop(&m.h).(storage.ChunkSeriesSet))
+	}
+
+	return len(m.currentSets) > 0
+}
+
+func (m *mergeChunkSeriesSet) At() storage.ChunkSeries {
+	if len(m.currentSets) == 1 {
+		return m.currentSets[0].At()
+	}
+	series := make([]storage.ChunkSeries, 0, len(m.currentSets))
+	for _, seriesSet := range m.currentSets {
+		series = append(series, seriesSet.At())
+	}
+	return m.mergeFunc(series...)
+}
+
+func (m *mergeChunkSeriesSet) Err() error {
+	return m.err
+}
+
+func (m *mergeChunkSeriesSet) Warnings() annotations.Annotations {
+	return nil
+}
+
+type heapChunkSeries struct {
+	heap    []storage.ChunkSeriesSet
+	compare func(a, b labels.Labels) int
+}
+
+func (h *heapChunkSeries) Len() int { return len(h.heap) }
+
+func (h *heapChunkSeries) Less(i, j int) bool {
+	a, b := h.heap[i].At().Labels(), h.heap[j].At().Labels()
+	return h.compare(a, b) < 0
+}
+
+func (h *heapChunkSeries) Swap(i, j int) { h.heap[i], h.heap[j] = h.heap[j], h.heap[i] }
+
+func (h *heapChunkSeries) Push(x any) {
+	h.heap = append(h.heap, x.(storage.ChunkSeriesSet))
+}
+
+func (h *heapChunkSeries) Pop() any {
+	old := h.heap
+	n := len(old)
+	x := old[n-1]
+	h.heap = old[0 : n-1]
+	return x
+}

--- a/convert/merge.go
+++ b/convert/merge.go
@@ -1,3 +1,16 @@
+// Copyright 2021 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package convert
 
 import (

--- a/schema/schema_builder.go
+++ b/schema/schema_builder.go
@@ -28,7 +28,7 @@ type Builder struct {
 	mint, maxt        int64
 }
 
-func NewBuilder(mint, maxt int64, colDuration int64) *Builder {
+func NewBuilder(mint, maxt, colDuration int64) *Builder {
 	b := &Builder{
 		g:                 make(parquet.Group),
 		dataColDurationMs: colDuration,

--- a/search/rowrange.go
+++ b/search/rowrange.go
@@ -25,7 +25,7 @@ type rowRange struct {
 // intersect intersects the row ranges from left hand sight with the row ranges from rhs
 // it assumes that lhs and rhs are simplified and returns a simplified result.
 // it operates in o(l+r) time by cursoring through ranges with a two pointer approach.
-func intersectRowRanges(lhs []rowRange, rhs []rowRange) []rowRange {
+func intersectRowRanges(lhs, rhs []rowRange) []rowRange {
 	res := make([]rowRange, 0)
 	for l, r := 0, 0; l < len(lhs) && r < len(rhs); {
 		al, bl := lhs[l].from, lhs[l].from+lhs[l].count


### PR DESCRIPTION
This PR proposes moving the label-based sorting of series to the reader side, instead of performing it during the write phase.

Sorting during writing requires buffering all rows in memory (or on disk), including the data columns that hold the chunk bytes — which can be quite large. This leads to increased memory usage and complexity.

By shifting the sorting to read time:
*  We significantly simplify the write path.
* We can stream rows directly into a simple Parquet writer without buffering.

The resulting parquet file can still perform binary search on the sorted cols, as the reader would identify those cols as sorted by looking at the col chunks index.