### PR TITLE
Implement Sharded Parquet Writer

### DIFF
--- a/convert/convert.go
+++ b/convert/convert.go
@@ -42,6 +42,8 @@ var DefaultConvertOpts = convertOpts{
 	numRowGroups:      math.MaxInt32,
 	sortedLabels:      []string{labels.MetricName},
 	bloomfilterLabels: []string{labels.MetricName},
+	pageBufferSize:    parquet.DefaultPageBufferSize,
+	writeBufferSize:   parquet.DefaultWriteBufferSize,
 }
 
 type Convertible interface {
@@ -58,6 +60,8 @@ type convertOpts struct {
 	name              string
 	sortedLabels      []string
 	bloomfilterLabels []string
+	pageBufferSize    int
+	writeBufferSize   int
 }
 
 func (cfg convertOpts) buildBloomfilterColumns() []parquet.BloomFilterColumn {
@@ -81,15 +85,33 @@ func (cfg convertOpts) buildSortingColumns() []parquet.SortingColumn {
 
 type ConvertOption func(*convertOpts)
 
-func SortBy(labels ...string) ConvertOption {
+func WithSortBy(labels ...string) ConvertOption {
 	return func(opts *convertOpts) {
 		opts.sortedLabels = labels
 	}
 }
 
-func ColDuration(d time.Duration) ConvertOption {
+func WithColDuration(d time.Duration) ConvertOption {
 	return func(opts *convertOpts) {
 		opts.colDuration = d
+	}
+}
+
+func WithWriteBufferSize(s int) ConvertOption {
+	return func(opts *convertOpts) {
+		opts.writeBufferSize = s
+	}
+}
+
+func WithPageBufferSize(s int) ConvertOption {
+	return func(opts *convertOpts) {
+		opts.pageBufferSize = s
+	}
+}
+
+func WithName(name string) ConvertOption {
+	return func(opts *convertOpts) {
+		opts.name = name
 	}
 }
 

--- a/convert/convert.go
+++ b/convert/convert.go
@@ -111,6 +111,7 @@ func ConvertTSDBBlock(
 		return 0, err
 	}
 
+	defer func() { _ = rr.Close() }()
 	w := NewShardedWrite(rr, rr.Schema(), bkt, &cfg)
 	return w.currentShard, errors.Wrap(w.Write(ctx), "error writing block")
 }

--- a/convert/convert_test.go
+++ b/convert/convert_test.go
@@ -96,7 +96,7 @@ func Test_Convert_TSDB(t *testing.T) {
 			require.NoError(t, app.Commit())
 
 			h := st.Head()
-			shards, err := ConvertTSDBBlock(ctx, bkt, h.MinTime(), h.MaxTime(), []Convertible{h}, ColDuration(tt.dataColDuration), SortBy(labels.MetricName))
+			shards, err := ConvertTSDBBlock(ctx, bkt, h.MinTime(), h.MaxTime(), []Convertible{h}, WithColDuration(tt.dataColDuration), WithSortBy(labels.MetricName))
 			require.NoError(t, err)
 			require.Equal(t, 1, shards)
 
@@ -146,7 +146,7 @@ func Test_CreateParquetWithReducedTimestampSamples(t *testing.T) {
 	h := st.Head()
 	mint, maxt := (time.Minute * 30).Milliseconds(), (time.Minute*90).Milliseconds()-1
 
-	shards, err := ConvertTSDBBlock(ctx, bkt, mint, maxt, []Convertible{h}, ColDuration(time.Minute*10), SortBy(labels.MetricName))
+	shards, err := ConvertTSDBBlock(ctx, bkt, mint, maxt, []Convertible{h}, WithColDuration(time.Minute*10), WithSortBy(labels.MetricName))
 	require.NoError(t, err)
 	require.Equal(t, 1, shards)
 
@@ -233,7 +233,7 @@ func Test_SortedLabels(t *testing.T) {
 	h := st.Head()
 	h2 := st2.Head()
 	// lets sort first by `zzz` as its not the default sorting on TSDB
-	shards, err := ConvertTSDBBlock(ctx, bkt, 0, time.Minute.Milliseconds(), []Convertible{h2, h}, ColDuration(time.Minute*10), SortBy("zzz", labels.MetricName))
+	shards, err := ConvertTSDBBlock(ctx, bkt, 0, time.Minute.Milliseconds(), []Convertible{h2, h}, WithColDuration(time.Minute*10), WithSortBy("zzz", labels.MetricName))
 	require.NoError(t, err)
 	require.Equal(t, 1, shards)
 

--- a/convert/convert_test.go
+++ b/convert/convert_test.go
@@ -23,11 +23,14 @@ import (
 
 	"github.com/parquet-go/parquet-go"
 	"github.com/prometheus-community/parquet-common/schema"
+	"github.com/prometheus-community/parquet-common/util"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
 	"github.com/prometheus/prometheus/tsdb/chunks"
 	"github.com/prometheus/prometheus/util/teststorage"
 	"github.com/stretchr/testify/require"
+	"github.com/thanos-io/objstore"
+	"github.com/thanos-io/objstore/providers/filesystem"
 )
 
 func Test_Convert_TSDB(t *testing.T) {
@@ -75,6 +78,10 @@ func Test_Convert_TSDB(t *testing.T) {
 			st := teststorage.New(t)
 			t.Cleanup(func() { _ = st.Close() })
 
+			bkt, err := filesystem.NewBucket(t.TempDir())
+			require.NoError(t, err)
+			t.Cleanup(func() { _ = bkt.Close() })
+
 			app := st.Appender(ctx)
 			seriesHash := make(map[uint64]struct{})
 			for i := 0; i != 1_000; i++ {
@@ -89,38 +96,29 @@ func Test_Convert_TSDB(t *testing.T) {
 			require.NoError(t, app.Commit())
 
 			h := st.Head()
-			rr, err := newTsdbRowReader(ctx, h.MinTime(), h.MaxTime(), tt.dataColDuration.Milliseconds(), []Convertible{h})
+			shards, err := ConvertTSDBBlock(ctx, bkt, h.MinTime(), h.MaxTime(), []Convertible{h}, ColDuration(tt.dataColDuration), SortBy(labels.MetricName))
 			require.NoError(t, err)
+			require.Equal(t, 1, shards)
 
-			defer func() { _ = rr.Close() }()
+			labelsFileName := schema.LabelsPfileNameForShard(DefaultConvertOpts.name, 0)
+			chunksFileName := schema.ChunksPfileNameForShard(DefaultConvertOpts.name, 0)
+			lf, cf, err := openParquetFiles(ctx, bkt, labelsFileName, chunksFileName)
+			require.NoError(t, err)
+			series, chunks, err := readSeries(lf, cf)
+			require.NoError(t, err)
+			require.Equal(t, st.DB.Head().NumSeries(), uint64(len(series)))
+			require.Equal(t, st.DB.Head().NumSeries(), uint64(len(chunks)))
 
-			buf := make([]parquet.Row, 100)
-			chunksDecoder := schema.NewPrometheusParquetChunksDecoder(chunkenc.NewPool())
-			total := 0
-
-			for {
-				n, _ := rr.ReadRows(buf)
-				if n == 0 {
-					break
+			for i, s := range series {
+				require.Contains(t, seriesHash, s.Hash())
+				require.Len(t, chunks[i], tt.expectedNumberOfChunks)
+				totalSamples := 0
+				for _, c := range chunks[i] {
+					require.Equal(t, tt.expectedPointsPerChunk, c.Chunk.NumSamples())
+					totalSamples += c.Chunk.NumSamples()
 				}
-
-				total += n
-				series, chunks, err := rowToSeries(rr.tsdbSchema.Schema, chunksDecoder, buf[:n])
-				require.NoError(t, err)
-				require.Len(t, series, n)
-				for i, s := range series {
-					require.Contains(t, seriesHash, s.Hash())
-					require.Len(t, chunks[i], tt.expectedNumberOfChunks)
-					totalSamples := 0
-					for _, c := range chunks[i] {
-						require.Equal(t, tt.expectedPointsPerChunk, c.Chunk.NumSamples())
-						totalSamples += c.Chunk.NumSamples()
-					}
-					require.Equal(t, tt.numberOfSamples, totalSamples)
-				}
+				require.Equal(t, tt.numberOfSamples, totalSamples)
 			}
-
-			require.Equal(t, st.DB.Head().NumSeries(), uint64(total))
 		})
 	}
 }
@@ -129,6 +127,10 @@ func Test_CreateParquetWithReducedTimestampSamples(t *testing.T) {
 	ctx := context.Background()
 	st := teststorage.New(t)
 	t.Cleanup(func() { _ = st.Close() })
+
+	bkt, err := filesystem.NewBucket(t.TempDir())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = bkt.Close() })
 
 	app := st.Appender(ctx)
 
@@ -143,18 +145,20 @@ func Test_CreateParquetWithReducedTimestampSamples(t *testing.T) {
 
 	h := st.Head()
 	mint, maxt := (time.Minute * 30).Milliseconds(), (time.Minute*90).Milliseconds()-1
-	rr, err := newTsdbRowReader(ctx, mint, maxt, (time.Minute * 10).Milliseconds(), []Convertible{h})
+
+	shards, err := ConvertTSDBBlock(ctx, bkt, mint, maxt, []Convertible{h}, ColDuration(time.Minute*10), SortBy(labels.MetricName))
 	require.NoError(t, err)
-	defer func() { _ = rr.Close() }()
+	require.Equal(t, 1, shards)
+
+	labelsFileName := schema.LabelsPfileNameForShard(DefaultConvertOpts.name, 0)
+	chunksFileName := schema.ChunksPfileNameForShard(DefaultConvertOpts.name, 0)
+	lf, cf, err := openParquetFiles(ctx, bkt, labelsFileName, chunksFileName)
+	require.NoError(t, err)
+
 	// 6 data cols with 10 min duration
-	require.Len(t, rr.tsdbSchema.DataColsIndexes, 6)
+	require.Len(t, cf.Schema().Columns(), 6)
+	series, chunks, err := readSeries(lf, cf)
 
-	chunksDecoder := schema.NewPrometheusParquetChunksDecoder(chunkenc.NewPool())
-	buf := make([]parquet.Row, 100)
-	n, _ := rr.ReadRows(buf)
-	require.Equal(t, 1, n)
-
-	series, chunks, err := rowToSeries(rr.tsdbSchema.Schema, chunksDecoder, buf[:n])
 	require.NoError(t, err)
 	require.Len(t, series, 1)
 	require.Len(t, chunks, 1)
@@ -175,6 +179,10 @@ func Test_SortedLabels(t *testing.T) {
 	t.Cleanup(func() { _ = st.Close() })
 	st2 := teststorage.New(t)
 	t.Cleanup(func() { _ = st2.Close() })
+
+	bkt, err := filesystem.NewBucket(t.TempDir())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = bkt.Close() })
 
 	app := st.Appender(ctx)
 	app2 := st2.Appender(ctx)
@@ -225,16 +233,18 @@ func Test_SortedLabels(t *testing.T) {
 	h := st.Head()
 	h2 := st2.Head()
 	// lets sort first by `zzz` as its not the default sorting on TSDB
-	rr, err := newTsdbRowReader(ctx, 0, time.Minute.Milliseconds(), (time.Minute * 10).Milliseconds(), []Convertible{h, h2}, "zzz", labels.MetricName)
+	shards, err := ConvertTSDBBlock(ctx, bkt, 0, time.Minute.Milliseconds(), []Convertible{h2, h}, ColDuration(time.Minute*10), SortBy("zzz", labels.MetricName))
+	require.NoError(t, err)
+	require.Equal(t, 1, shards)
+
+	labelsFileName := schema.LabelsPfileNameForShard(DefaultConvertOpts.name, 0)
+	chunksFileName := schema.ChunksPfileNameForShard(DefaultConvertOpts.name, 0)
+	lf, cf, err := openParquetFiles(ctx, bkt, labelsFileName, chunksFileName)
 	require.NoError(t, err)
 
-	buf := make([]parquet.Row, h.NumSeries()+h2.NumSeries())
-	n, _ := rr.ReadRows(buf)
-	require.Equal(t, totalSeries, n)
-
-	series, chunks, err := rowToSeries(rr.tsdbSchema.Schema, schema.NewPrometheusParquetChunksDecoder(chunkenc.NewPool()), buf[:n])
+	series, chunks, err := readSeries(lf, cf)
 	require.NoError(t, err)
-	require.Len(t, series, n)
+	require.Len(t, series, totalSeries)
 
 	for i := 0; i < len(series)-1; i++ {
 		require.LessOrEqual(t, series[i].Get("zzz"), series[i+1].Get("zzz"))
@@ -257,6 +267,63 @@ func Test_SortedLabels(t *testing.T) {
 
 		require.NoError(t, st.Err())
 	}
+}
+
+func openParquetFiles(ctx context.Context, bkt objstore.Bucket, labelsFileName, chunksFileName string) (*parquet.File, *parquet.File, error) {
+	labelsAttr, err := bkt.Attributes(ctx, labelsFileName)
+	if err != nil {
+		return nil, nil, err
+	}
+	labelsFile, err := parquet.OpenFile(util.NewBucketReadAt(ctx, labelsFileName, bkt), labelsAttr.Size)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	chunksAttr, err := bkt.Attributes(ctx, chunksFileName)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	chunksFile, err := parquet.OpenFile(util.NewBucketReadAt(ctx, chunksFileName, bkt), chunksAttr.Size)
+	if err != nil {
+		return nil, nil, err
+	}
+	return labelsFile, chunksFile, nil
+}
+
+func readSeries(labelsFile, chunksFile *parquet.File) ([]labels.Labels, [][]chunks.Meta, error) {
+	lr := parquet.NewGenericReader[any](labelsFile)
+	cr := parquet.NewGenericReader[any](chunksFile)
+
+	labelsBuff := make([]parquet.Row, 100)
+	chunksBuff := make([]parquet.Row, 100)
+	rLbls := make([]labels.Labels, 0, 100)
+	rChunks := make([][]chunks.Meta, 0, 100)
+	dec := schema.NewPrometheusParquetChunksDecoder(chunkenc.NewPool())
+	for {
+		nl, _ := lr.ReadRows(labelsBuff)
+		if nl == 0 {
+			break
+		}
+
+		nc, _ := cr.ReadRows(chunksBuff)
+
+		if nc != nl {
+			return nil, nil, fmt.Errorf("unexpected number of rows read: %d, expected %d", nl, nc)
+		}
+		s, _, err := rowToSeries(lr.Schema(), dec, labelsBuff[:nl])
+		if err != nil {
+			return nil, nil, err
+		}
+		_, c, err := rowToSeries(cr.Schema(), dec, chunksBuff[:nl])
+		if err != nil {
+			return nil, nil, err
+		}
+		rLbls = append(rLbls, s...)
+		rChunks = append(rChunks, c...)
+	}
+
+	return rLbls, rChunks, nil
 }
 
 func rowToSeries(s *parquet.Schema, dec *schema.PrometheusParquetChunksDecoder, rows []parquet.Row) ([]labels.Labels, [][]chunks.Meta, error) {

--- a/convert/writer.go
+++ b/convert/writer.go
@@ -69,11 +69,12 @@ func (c *ShardedWriter) convertShard(ctx context.Context) (bool, error) {
 		return false, err
 	}
 
+	c.currentShard++
+
 	if n < int64(rowsToWrite) {
 		return false, nil
 	}
 
-	c.currentShard++
 	return true, nil
 }
 

--- a/convert/writer.go
+++ b/convert/writer.go
@@ -1,0 +1,216 @@
+package convert
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/parquet-go/parquet-go"
+	"github.com/prometheus-community/parquet-common/schema"
+	"github.com/prometheus-community/parquet-common/util"
+	"github.com/thanos-io/objstore"
+	"golang.org/x/sync/errgroup"
+)
+
+type ShardedWriter struct {
+	name string
+
+	rowGroupSize int
+	numRowGroups int
+
+	currentShard int
+
+	rr  parquet.RowReader
+	s   *schema.TSDBSchema
+	bkt objstore.Bucket
+
+	sortingColumns     []parquet.SortingColumn
+	bloomfilterColumns []parquet.BloomFilterColumn
+}
+
+func NewShardedWrite(rr parquet.RowReader, s *schema.TSDBSchema, bkt objstore.Bucket, ops *convertOpts) *ShardedWriter {
+	return &ShardedWriter{
+		name:               ops.name,
+		rowGroupSize:       ops.rowGroupSize,
+		numRowGroups:       ops.numRowGroups,
+		currentShard:       0,
+		rr:                 rr,
+		s:                  s,
+		bkt:                bkt,
+		sortingColumns:     ops.buildSortingColumns(),
+		bloomfilterColumns: ops.buildBloomfilterColumns(),
+	}
+}
+
+func (c *ShardedWriter) Write(ctx context.Context) error {
+	if err := c.convertShards(ctx); err != nil {
+		return fmt.Errorf("unable to convert shards: %w", err)
+	}
+	return nil
+}
+
+func (c *ShardedWriter) convertShards(ctx context.Context) error {
+	for {
+		if ok, err := c.convertShard(ctx); err != nil {
+			return fmt.Errorf("unable to convert shard: %s", err)
+		} else if !ok {
+			break
+		}
+	}
+	return nil
+}
+
+func (c *ShardedWriter) convertShard(ctx context.Context) (bool, error) {
+	rowsToWrite := c.numRowGroups * c.rowGroupSize
+
+	n, err := c.writeFile(ctx, c.s.Schema, rowsToWrite)
+	if err != nil {
+		return false, err
+	}
+
+	if n < int64(rowsToWrite) {
+		return false, nil
+	}
+
+	c.currentShard++
+	return true, nil
+}
+
+func (c *ShardedWriter) writeFile(ctx context.Context, inSchema *parquet.Schema, rowsToWrite int) (int64, error) {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	writer, err := newSplitFileWriter(ctx, c.bkt, inSchema, c.transformations(),
+		parquet.SortingWriterConfig(
+			parquet.SortingColumns(c.sortingColumns...),
+		),
+		parquet.MaxRowsPerRowGroup(int64(c.rowGroupSize)),
+		parquet.BloomFilters(c.bloomfilterColumns...),
+	)
+	if err != nil {
+		return 0, fmt.Errorf("unable to create row writer: %s", err)
+	}
+
+	n, err := parquet.CopyRows(writer, newLimitReader(c.rr, rowsToWrite))
+	if err != nil {
+		return 0, fmt.Errorf("unable to copy rows: %s", err)
+	}
+
+	err = writer.Close()
+	if err != nil {
+		return 0, fmt.Errorf("unable to close writer: %s", err)
+	}
+
+	return n, nil
+}
+
+func (c *ShardedWriter) transformations() map[string]*parquet.Schema {
+	return map[string]*parquet.Schema{
+		schema.LabelsPfileNameForShard(c.name, c.currentShard): schema.WithCompression(c.s.LabelsProjection()),
+		schema.ChunksPfileNameForShard(c.name, c.currentShard): schema.WithCompression(c.s.ChunksProjection()),
+	}
+}
+
+var _ parquet.RowWriter = &splitPipeFileWriter{}
+
+type fileWriter struct {
+	pw   *parquet.GenericWriter[any]
+	conv parquet.Conversion
+	w    io.WriteCloser
+	r    io.ReadCloser
+}
+
+type splitPipeFileWriter struct {
+	fileWriters map[string]*fileWriter
+	errGroup    *errgroup.Group
+}
+
+func newSplitFileWriter(ctx context.Context, bkt objstore.Bucket, inSchema *parquet.Schema,
+	files map[string]*parquet.Schema, options ...parquet.WriterOption,
+) (*splitPipeFileWriter, error) {
+	fileWriters := make(map[string]*fileWriter)
+	errGroup, ctx := errgroup.WithContext(ctx)
+	for file, outSchema := range files {
+		conv, err := parquet.Convert(outSchema, inSchema)
+		if err != nil {
+			return nil, fmt.Errorf("unable to convert schemas")
+		}
+
+		r, w := io.Pipe()
+		fileWriters[file] = &fileWriter{
+			pw:   parquet.NewGenericWriter[any](w, append(options, outSchema)...),
+			w:    w,
+			r:    r,
+			conv: conv,
+		}
+		errGroup.Go(func() error {
+			defer func() { _ = r.Close() }()
+			return bkt.Upload(ctx, file, r)
+		})
+	}
+	return &splitPipeFileWriter{
+		fileWriters: fileWriters,
+		errGroup:    errGroup,
+	}, nil
+}
+
+func (s *splitPipeFileWriter) WriteRows(rows []parquet.Row) (int, error) {
+	for _, writer := range s.fileWriters {
+		convertedRows := util.CloneRows(rows)
+		_, err := writer.conv.Convert(convertedRows)
+		if err != nil {
+			return 0, fmt.Errorf("unable to convert rows: %d", err)
+		}
+		n, err := writer.pw.WriteRows(convertedRows)
+		if err != nil {
+			return 0, fmt.Errorf("unable to write rows: %d", err)
+		}
+		if n != len(rows) {
+			return 0, fmt.Errorf("unable to write rows: %d != %d", n, len(rows))
+		}
+	}
+
+	return len(rows), nil
+}
+
+func (s *splitPipeFileWriter) Close() error {
+	var err error
+	for _, fw := range s.fileWriters {
+		if errClose := fw.pw.Close(); errClose != nil {
+			err = multierror.Append(err, errClose)
+		}
+		if errClose := fw.w.Close(); errClose != nil {
+			err = multierror.Append(err, errClose)
+		}
+	}
+
+	if errClose := s.errGroup.Wait(); errClose != nil {
+		err = multierror.Append(err, errClose)
+	}
+	return err
+}
+
+type limitReader struct {
+	parquet.RowReader
+	remaining int
+}
+
+func newLimitReader(r parquet.RowReader, limit int) parquet.RowReader {
+	return &limitReader{RowReader: r, remaining: limit}
+}
+
+func (lr *limitReader) ReadRows(buf []parquet.Row) (int, error) {
+	if len(buf) > lr.remaining {
+		buf = buf[:lr.remaining]
+	}
+	n, err := lr.RowReader.ReadRows(buf)
+	if err != nil {
+		return n, err
+	}
+	lr.remaining -= n
+
+	if lr.remaining <= 0 {
+		return n, io.EOF
+	}
+	return n, nil
+}

--- a/convert/writer.go
+++ b/convert/writer.go
@@ -1,3 +1,16 @@
+// Copyright 2021 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package convert
 
 import (

--- a/convert/writer_test.go
+++ b/convert/writer_test.go
@@ -1,0 +1,132 @@
+package convert
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"math"
+	"testing"
+	"time"
+
+	"github.com/parquet-go/parquet-go"
+	"github.com/prometheus-community/parquet-common/schema"
+	"github.com/prometheus-community/parquet-common/util"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/tsdb/chunkenc"
+	"github.com/prometheus/prometheus/tsdb/chunks"
+	"github.com/prometheus/prometheus/util/teststorage"
+	"github.com/stretchr/testify/require"
+	"github.com/thanos-io/objstore/providers/filesystem"
+)
+
+func TestParquetWriter(t *testing.T) {
+	ctx := context.Background()
+	st := teststorage.New(t)
+	t.Cleanup(func() { _ = st.Close() })
+
+	bkt, err := filesystem.NewBucket(t.TempDir())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = bkt.Close() })
+
+	app := st.Appender(ctx)
+
+	totalNumberOfSeries := 1_150
+	for i := 0; i != totalNumberOfSeries; i++ {
+		for j := 0; j < 10; j++ {
+			lbls := labels.FromStrings(labels.MetricName, fmt.Sprintf("foo_%d", i), "bar", fmt.Sprintf("%d", 2*i))
+			_, err := app.Append(0, lbls, (time.Minute * time.Duration(j)).Milliseconds(), float64(i))
+			require.NoError(t, err)
+		}
+	}
+
+	require.NoError(t, app.Commit())
+	h := st.Head()
+	mint, maxt := (time.Minute * 30).Milliseconds(), (time.Minute*90).Milliseconds()-1
+
+	convertsOpts := DEFAULT_CONVERT_OPTS
+
+	// 2 row groups of size 100 per file
+	convertsOpts.numRowGroups = 3
+	convertsOpts.rowGroupSize = 100
+	convertsOpts.sortedLabels = []string{labels.MetricName, "bar"}
+
+	rr, err := newTsdbRowReader(ctx, mint, maxt, (time.Minute * 10).Milliseconds(), []Convertible{h}, convertsOpts.sortedLabels...)
+	require.NoError(t, err)
+	defer func() { _ = rr.Close() }()
+
+	sw := NewShardedWrite(rr, rr.tsdbSchema, bkt, convertsOpts)
+	err = sw.Write(ctx)
+	require.NoError(t, err)
+
+	totalShards := int(math.Ceil(float64(totalNumberOfSeries) / float64(convertsOpts.numRowGroups*convertsOpts.rowGroupSize)))
+	remainingRows := totalNumberOfSeries
+	chunksDecoder := schema.NewPrometheusParquetChunksDecoder(chunkenc.NewPool())
+	buf := make([]parquet.Row, totalNumberOfSeries)
+	fSeries := make([]labels.Labels, 0, totalNumberOfSeries)
+	fChunks := make([][]chunks.Meta, 0, totalNumberOfSeries)
+
+	for i := 0; i < totalShards; i++ {
+		labelsFileName := schema.LabelsPfileNameForShard(convertsOpts.name, i)
+		fmt.Println(labelsFileName)
+		labelsAttr, err := bkt.Attributes(ctx, labelsFileName)
+		require.NoError(t, err)
+
+		labelsFile, err := parquet.OpenFile(util.NewBucketReadAt(ctx, labelsFileName, bkt), labelsAttr.Size)
+		require.NoError(t, err)
+
+		// Inspect row groups
+		for _, group := range labelsFile.RowGroups() {
+			require.LessOrEqual(t, group.NumRows(), int64(convertsOpts.rowGroupSize))
+			for i, sortingCol := range convertsOpts.buildSortingColumns() {
+				require.Equal(t, sortingCol.Path(), group.SortingColumns()[i].Path())
+				require.Equal(t, sortingCol.Descending(), group.SortingColumns()[i].Descending())
+				require.Equal(t, sortingCol.NullsFirst(), group.SortingColumns()[i].NullsFirst())
+			}
+		}
+
+		lr := parquet.NewGenericReader[any](labelsFile)
+		n, err := lr.ReadRows(buf)
+		// Read the whole file
+		require.ErrorIs(t, err, io.EOF)
+		require.Equal(t, math.Min(float64(remainingRows), float64(convertsOpts.numRowGroups*convertsOpts.rowGroupSize)), float64(n))
+
+		series, chunks, err := rowToSeries(labelsFile.Schema(), chunksDecoder, buf[:n])
+		require.NoError(t, err)
+		require.Len(t, series, n)
+		require.Len(t, chunks, n)
+		fSeries = append(fSeries, series...)
+		// Should not have any chunk data on the labels file
+		for _, chunk := range chunks {
+			require.Len(t, chunk, 0)
+		}
+
+		chunksFileName := schema.ChunksPfileNameForShard(convertsOpts.name, i)
+		fmt.Println(chunksFileName)
+		chunksAttr, err := bkt.Attributes(ctx, chunksFileName)
+		require.NoError(t, err)
+
+		chunksFile, err := parquet.OpenFile(util.NewBucketReadAt(ctx, chunksFileName, bkt), chunksAttr.Size)
+		require.NoError(t, err)
+
+		cr := parquet.NewGenericReader[any](chunksFile)
+		n, err = cr.ReadRows(buf)
+		// Read the whole file
+		require.ErrorIs(t, err, io.EOF)
+		require.Equal(t, math.Min(float64(remainingRows), float64(convertsOpts.numRowGroups*convertsOpts.rowGroupSize)), float64(n))
+
+		series, chunks, err = rowToSeries(chunksFile.Schema(), chunksDecoder, buf[:n])
+		require.NoError(t, err)
+		require.Len(t, series, n)
+		require.Len(t, chunks, n)
+		fChunks = append(fChunks, chunks...)
+
+		// Should not have any label
+		for _, l := range series {
+			require.Len(t, l, 0)
+		}
+
+		remainingRows -= n
+	}
+	require.Len(t, fSeries, totalNumberOfSeries)
+	require.Len(t, fChunks, totalNumberOfSeries)
+}

--- a/convert/writer_test.go
+++ b/convert/writer_test.go
@@ -48,6 +48,7 @@ func TestParquetWriter(t *testing.T) {
 	// 2 row groups of size 100 per file
 	convertsOpts.numRowGroups = 3
 	convertsOpts.rowGroupSize = 100
+	convertsOpts.writeBufferSize = 10
 	convertsOpts.sortedLabels = []string{labels.MetricName, "bar"}
 
 	rr, err := NewTsdbRowReader(ctx, mint, maxt, (time.Minute * 10).Milliseconds(), []Convertible{h}, convertsOpts.sortedLabels...)

--- a/convert/writer_test.go
+++ b/convert/writer_test.go
@@ -1,3 +1,16 @@
+// Copyright 2021 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package convert
 
 import (

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/parquet-go/parquet-go"
 	"github.com/parquet-go/parquet-go/compress/zstd"
+	"github.com/parquet-go/parquet-go/format"
 )
 
 const (
@@ -26,6 +27,8 @@ const (
 	DataColumnPrefix  = "s_data_"
 
 	DataColSizeMd = "data_col_duration_ms"
+	MinTMd        = "minT"
+	MaxTMd        = "maxT"
 )
 
 func LabelToColumn(lbl string) string {
@@ -65,4 +68,12 @@ func WithCompression(s *parquet.Schema) *parquet.Schema {
 	}
 
 	return parquet.NewSchema("uncompressed", g)
+}
+
+func MetadataToMap(md []format.KeyValue) map[string]string {
+	r := make(map[string]string, len(md))
+	for _, kv := range md {
+		r[kv.Key] = kv.Value
+	}
+	return r
 }

--- a/schema/schema_builder.go
+++ b/schema/schema_builder.go
@@ -94,3 +94,35 @@ func (s *TSDBSchema) DataColumIdx(t int64) int {
 
 	return colIdx
 }
+
+func (s *TSDBSchema) LabelsProjection() *parquet.Schema {
+	g := make(parquet.Group)
+
+	for _, c := range s.Schema.Columns() {
+		if _, ok := ExtractLabelFromColumn(c[0]); !ok {
+			continue
+		}
+		lc, ok := s.Schema.Lookup(c...)
+		if !ok {
+			continue
+		}
+		g[c[0]] = lc.Node
+	}
+	return parquet.NewSchema("labels-projection", g)
+}
+
+func (s *TSDBSchema) ChunksProjection() *parquet.Schema {
+	g := make(parquet.Group)
+
+	for _, c := range s.Schema.Columns() {
+		if ok := IsDataColumn(c[0]); !ok {
+			continue
+		}
+		lc, ok := s.Schema.Lookup(c...)
+		if !ok {
+			continue
+		}
+		g[c[0]] = lc.Node
+	}
+	return parquet.NewSchema("chunk-projection", g)
+}

--- a/schema/schema_builder.go
+++ b/schema/schema_builder.go
@@ -34,6 +34,8 @@ func NewBuilder(mint, maxt, colDuration int64) *Builder {
 		dataColDurationMs: colDuration,
 		metadata: map[string]string{
 			DataColSizeMd: strconv.FormatInt(colDuration, 10),
+			MaxTMd:        strconv.FormatInt(maxt, 10),
+			MinTMd:        strconv.FormatInt(mint, 10),
 		},
 		mint: mint,
 		maxt: maxt,

--- a/util/bucket_read_at.go
+++ b/util/bucket_read_at.go
@@ -26,7 +26,7 @@ func (b *bReadAt) ReadAt(p []byte, off int64) (n int, err error) {
 	if err != nil {
 		return 0, err
 	}
-	defer rc.Close()
+	defer func() { _ = rc.Close() }()
 	n, err = rc.Read(p)
 	if err == io.EOF {
 		err = nil

--- a/util/bucket_read_at.go
+++ b/util/bucket_read_at.go
@@ -1,0 +1,35 @@
+package util
+
+import (
+	"context"
+	"io"
+
+	"github.com/thanos-io/objstore"
+)
+
+type bReadAt struct {
+	path string
+	obj  objstore.Bucket
+	ctx  context.Context
+}
+
+func NewBucketReadAt(ctx context.Context, path string, obj objstore.Bucket) io.ReaderAt {
+	return &bReadAt{
+		path: path,
+		obj:  obj,
+		ctx:  ctx,
+	}
+}
+
+func (b *bReadAt) ReadAt(p []byte, off int64) (n int, err error) {
+	rc, err := b.obj.GetRange(b.ctx, b.path, off, int64(len(p)))
+	if err != nil {
+		return 0, err
+	}
+	defer rc.Close()
+	n, err = rc.Read(p)
+	if err == io.EOF {
+		err = nil
+	}
+	return
+}

--- a/util/util.go
+++ b/util/util.go
@@ -1,0 +1,11 @@
+package util
+
+import "github.com/parquet-go/parquet-go"
+
+func CloneRows(rows []parquet.Row) []parquet.Row {
+	rr := make([]parquet.Row, len(rows))
+	for i, row := range rows {
+		rr[i] = row.Clone()
+	}
+	return rr
+}


### PR DESCRIPTION

**Implement Sharded Parquet Writer**

This PR introduces a sharded Parquet writer that generates Parquet files from a `parquet.RowReader` input.

For each shard, the writer produces two files:
- **Labels file** (`<shard>.labels.parquet`) — contains the series labels.
- **Chunks file** (`<shard>.chunks.parquet`) — contains the encoded time series chunks.

The writer processes the input in a single pass, piping rows directly from the reader to the output files to avoid in-memory buffering.

### Example:

Converting a TSDB block with 1,150 rows and a shard size of 300 will produce:

```
block/0.labels.parquet
block/0.chunks.parquet
block/1.labels.parquet
block/1.chunks.parquet
block/2.labels.parquet
block/2.chunks.parquet
block/3.labels.parquet
block/3.chunks.parquet
```

This approach enables efficient, memory-safe conversion of large TSDB blocks into sharded Parquet files.