### PR TITLE
Allowing to configure `ColumnPageBuffers` and adding some concurrency on the tsdb conversion

### DIFF
--- a/convert/convert.go
+++ b/convert/convert.go
@@ -37,13 +37,14 @@ import (
 
 var DefaultConvertOpts = convertOpts{
 	name:              "block",
-	rowGroupSize:      1_000_000,
+	rowGroupSize:      1e6,
 	colDuration:       time.Hour * 8,
 	numRowGroups:      math.MaxInt32,
 	sortedLabels:      []string{labels.MetricName},
 	bloomfilterLabels: []string{labels.MetricName},
 	pageBufferSize:    parquet.DefaultPageBufferSize,
 	writeBufferSize:   parquet.DefaultWriteBufferSize,
+	columnPageBuffers: parquet.DefaultWriterConfig().ColumnPageBuffers,
 }
 
 type Convertible interface {
@@ -62,6 +63,7 @@ type convertOpts struct {
 	bloomfilterLabels []string
 	pageBufferSize    int
 	writeBufferSize   int
+	columnPageBuffers parquet.BufferPool
 }
 
 func (cfg convertOpts) buildBloomfilterColumns() []parquet.BloomFilterColumn {
@@ -112,6 +114,12 @@ func WithPageBufferSize(s int) ConvertOption {
 func WithName(name string) ConvertOption {
 	return func(opts *convertOpts) {
 		opts.name = name
+	}
+}
+
+func WithColumnPageBuffers(buffers parquet.BufferPool) ConvertOption {
+	return func(opts *convertOpts) {
+		opts.columnPageBuffers = buffers
 	}
 }
 

--- a/convert/convert_test.go
+++ b/convert/convert_test.go
@@ -148,7 +148,14 @@ func Test_CreateParquetWithReducedTimestampSamples(t *testing.T) {
 	mint, maxt := (time.Minute * 30).Milliseconds(), (time.Minute*90).Milliseconds()-1
 
 	datColDuration := time.Minute * 10
-	shards, err := ConvertTSDBBlock(ctx, bkt, mint, maxt, []Convertible{h}, WithColDuration(datColDuration), WithSortBy(labels.MetricName))
+	shards, err := ConvertTSDBBlock(
+		ctx, bkt, mint, maxt,
+		[]Convertible{h},
+		WithColDuration(datColDuration),
+		WithSortBy(labels.MetricName),
+		WithColumnPageBuffers(parquet.NewFileBufferPool(t.TempDir(), "buffers.*")),
+	)
+
 	require.NoError(t, err)
 	require.Equal(t, 1, shards)
 
@@ -242,7 +249,16 @@ func Test_SortedLabels(t *testing.T) {
 	h := st.Head()
 	h2 := st2.Head()
 	// lets sort first by `zzz` as its not the default sorting on TSDB
-	shards, err := ConvertTSDBBlock(ctx, bkt, 0, time.Minute.Milliseconds(), []Convertible{h2, h}, WithColDuration(time.Minute*10), WithSortBy("zzz", labels.MetricName))
+	shards, err := ConvertTSDBBlock(
+		ctx,
+		bkt,
+		0,
+		time.Minute.Milliseconds(),
+		[]Convertible{h2, h},
+		WithColDuration(time.Minute*10),
+		WithSortBy("zzz", labels.MetricName),
+		WithColumnPageBuffers(parquet.NewFileBufferPool(t.TempDir(), "buffers.*")),
+	)
 	require.NoError(t, err)
 	require.Equal(t, 1, shards)
 


### PR DESCRIPTION
Minor improvements:

* Allow configuration of ColumnPageBuffers.
* Add concurrency to parallelize TSDB reading and writing of chunk/label files.