### PR TITLE
converter: fix early io.EOF

### DIFF
--- a/convert/writer_test.go
+++ b/convert/writer_test.go
@@ -54,7 +54,6 @@ func TestParquetWriter(t *testing.T) {
 
 	require.NoError(t, app.Commit())
 	h := st.Head()
-	mint, maxt := (time.Minute * 30).Milliseconds(), (time.Minute*90).Milliseconds()-1
 
 	convertsOpts := DefaultConvertOpts
 
@@ -64,7 +63,7 @@ func TestParquetWriter(t *testing.T) {
 	convertsOpts.writeBufferSize = 10
 	convertsOpts.sortedLabels = []string{labels.MetricName, "bar"}
 
-	rr, err := NewTsdbRowReader(ctx, mint, maxt, (time.Minute * 10).Milliseconds(), []Convertible{h}, convertsOpts)
+	rr, err := NewTsdbRowReader(ctx, h.MinTime(), h.MaxTime(), (time.Minute * 10).Milliseconds(), []Convertible{h}, convertsOpts)
 	require.NoError(t, err)
 	defer func() { _ = rr.Close() }()
 

--- a/schema/encoder.go
+++ b/schema/encoder.go
@@ -74,6 +74,7 @@ func (e *PrometheusParquetChunksEncoder) Encode(it chunks.Iterator) ([][]byte, e
 					return nil, fmt.Errorf("found value type %v in float chunk", vt)
 				}
 				t, v := sampleIt.At()
+
 				chkIdx := e.schema.DataColumIdx(t)
 				reEncodedChunksAppenders[chkIdx].Append(t, v)
 				if t < reEncodedChunks[chkIdx].MinTime {
@@ -91,6 +92,9 @@ func (e *PrometheusParquetChunksEncoder) Encode(it chunks.Iterator) ([][]byte, e
 	result := make([][]byte, dataColSize)
 
 	for i, chk := range reEncodedChunks {
+		if chk.Chunk.NumSamples() == 0 {
+			continue
+		}
 		var b [varint.MaxLen64]byte
 		n := binary.PutUvarint(b[:], uint64(chk.Chunk.Encoding()))
 		result[i] = append(result[i], b[:n]...)


### PR DESCRIPTION
If all chunks are empty for a series we would early return io.EOF because we skipped a series. Additionally we fix an issue where the encoder returns empty chunks.