### PR TITLE
Store Column Indexes in Dedicated Column (`s_col_indexes`)

### DIFF
--- a/convert/writer_test.go
+++ b/convert/writer_test.go
@@ -102,7 +102,7 @@ func TestParquetWriter(t *testing.T) {
 		require.ErrorIs(t, err, io.EOF)
 		require.Equal(t, math.Min(float64(remainingRows), float64(convertsOpts.numRowGroups*convertsOpts.rowGroupSize)), float64(n))
 
-		series, chunks, err := rowToSeries(labelsFile.Schema(), chunksDecoder, buf[:n])
+		series, chunks, err := rowToSeries(t, labelsFile.Schema(), chunksDecoder, buf[:n])
 		require.NoError(t, err)
 		require.Len(t, series, n)
 		require.Len(t, chunks, n)
@@ -125,7 +125,7 @@ func TestParquetWriter(t *testing.T) {
 		require.ErrorIs(t, err, io.EOF)
 		require.Equal(t, math.Min(float64(remainingRows), float64(convertsOpts.numRowGroups*convertsOpts.rowGroupSize)), float64(n))
 
-		series, chunks, err = rowToSeries(chunksFile.Schema(), chunksDecoder, buf[:n])
+		series, chunks, err = rowToSeries(t, chunksFile.Schema(), chunksDecoder, buf[:n])
 		require.NoError(t, err)
 		require.Len(t, series, n)
 		require.Len(t, chunks, n)

--- a/schema/encoder.go
+++ b/schema/encoder.go
@@ -18,6 +18,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"math"
+	"slices"
 	"sort"
 
 	"github.com/dennwc/varint"
@@ -160,4 +161,45 @@ func (e *PrometheusParquetChunksDecoder) Decode(data []byte, mint, maxt int64) (
 	}
 
 	return result, nil
+}
+
+func EncodeIntSlice(s []int) []byte {
+	l := make([]byte, binary.MaxVarintLen32)
+	r := make([]byte, 0, len(s)*binary.MaxVarintLen32)
+
+	// Sort to compress more efficiently
+	slices.Sort(s)
+
+	// size
+	n := binary.PutVarint(l[:], int64(len(s)))
+	r = append(r, l[:n]...)
+
+	for i := 0; i < len(s); i++ {
+		n := binary.PutVarint(l[:], int64(s[i]))
+		r = append(r, l[:n]...)
+	}
+
+	return r
+}
+
+func DecodeUintSlice(b []byte) ([]int, error) {
+	buffer := bytes.NewBuffer(b)
+
+	// size
+	s, err := binary.ReadVarint(buffer)
+	if err != nil {
+		return nil, err
+	}
+
+	r := make([]int, 0, s)
+
+	for i := int64(0); i < s; i++ {
+		v, err := binary.ReadVarint(buffer)
+		if err != nil {
+			return nil, err
+		}
+		r = append(r, int(v))
+	}
+
+	return r, nil
 }

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -25,6 +25,7 @@ import (
 const (
 	LabelColumnPrefix = "l_"
 	DataColumnPrefix  = "s_data_"
+	ColIndexes        = "s_col_indexes"
 
 	DataColSizeMd = "data_col_duration_ms"
 	MinTMd        = "minT"


### PR DESCRIPTION

**Store Column Indexes in Dedicated Column (`s_col_indexes`)**

This change introduces a new special column named `s_col_indexes`, which stores the indexes of the data columns associated with each series.

This column will enable future optimizations by allowing readers to materialize only the necessary columns when accessing a series, reducing I/O and memory usage during queries.