### PR TITLE
search: add null constraint

### DIFF
--- a/search/constraint.go
+++ b/search/constraint.go
@@ -295,3 +295,21 @@ func (nc *notConstraint) init(s *parquet.Schema) error {
 func (nc *notConstraint) path() string {
 	return nc.c.path()
 }
+
+type nullConstraint struct{}
+
+func Null() Constraint {
+	return &nullConstraint{}
+}
+
+func (null *nullConstraint) filter(parquet.RowGroup, bool, []rowRange) ([]rowRange, error) {
+	return nil, nil
+}
+
+func (null *nullConstraint) init(_ *parquet.Schema) error {
+	return nil
+}
+
+func (null *nullConstraint) path() string {
+	return ""
+}


### PR DESCRIPTION
This commit adds a null constraint that never matches any rows. This is useful if we get a query that matches on a nonexisting column.