### PR TITLE
Implement Parquet Materializer

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -23,7 +23,11 @@ linters:
 
 formatters:
   enable:
-    - gci
     - gofmt
     - gofumpt
     - goimports
+
+  settings:
+    goimports:
+      local-prefixes:
+        - github.com/prometheus-community/parquet-common

--- a/convert/convert.go
+++ b/convert/convert.go
@@ -23,16 +23,17 @@ import (
 	"strings"
 	"time"
 
+	"github.com/efficientgo/core/errors"
 	"github.com/hashicorp/go-multierror"
 	"github.com/parquet-go/parquet-go"
-	"github.com/pkg/errors"
-	"github.com/prometheus-community/parquet-common/schema"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/tsdb"
 	"github.com/prometheus/prometheus/tsdb/index"
 	"github.com/prometheus/prometheus/tsdb/tombstones"
 	"github.com/thanos-io/objstore"
+
+	"github.com/prometheus-community/parquet-common/schema"
 )
 
 var DefaultConvertOpts = convertOpts{
@@ -116,6 +117,18 @@ func WithPageBufferSize(s int) ConvertOption {
 func WithName(name string) ConvertOption {
 	return func(opts *convertOpts) {
 		opts.name = name
+	}
+}
+
+func WithNumRowGroups(n int) ConvertOption {
+	return func(opts *convertOpts) {
+		opts.numRowGroups = n
+	}
+}
+
+func WithRowGroupSize(size int) ConvertOption {
+	return func(opts *convertOpts) {
+		opts.rowGroupSize = size
 	}
 }
 

--- a/convert/writer.go
+++ b/convert/writer.go
@@ -18,14 +18,15 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/efficientgo/core/errors"
 	"github.com/hashicorp/go-multierror"
 	"github.com/parquet-go/parquet-go"
-	"github.com/pkg/errors"
-	"github.com/prometheus-community/parquet-common/schema"
-	"github.com/prometheus-community/parquet-common/util"
 	"github.com/prometheus/prometheus/util/zeropool"
 	"github.com/thanos-io/objstore"
 	"golang.org/x/sync/errgroup"
+
+	"github.com/prometheus-community/parquet-common/schema"
+	"github.com/prometheus-community/parquet-common/util"
 )
 
 type ShardedWriter struct {

--- a/convert/writer_test.go
+++ b/convert/writer_test.go
@@ -22,14 +22,15 @@ import (
 	"time"
 
 	"github.com/parquet-go/parquet-go"
-	"github.com/prometheus-community/parquet-common/schema"
-	"github.com/prometheus-community/parquet-common/util"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
 	"github.com/prometheus/prometheus/tsdb/chunks"
 	"github.com/prometheus/prometheus/util/teststorage"
 	"github.com/stretchr/testify/require"
 	"github.com/thanos-io/objstore/providers/filesystem"
+
+	"github.com/prometheus-community/parquet-common/schema"
+	"github.com/prometheus-community/parquet-common/util"
 )
 
 func TestParquetWriter(t *testing.T) {
@@ -118,6 +119,9 @@ func TestParquetWriter(t *testing.T) {
 
 		chunksFile, err := parquet.OpenFile(util.NewBucketReadAt(ctx, chunksFileName, bkt), chunksAttr.Size)
 		require.NoError(t, err)
+
+		// should have the same number of row groups
+		require.Equal(t, len(chunksFile.RowGroups()), len(chunksFile.RowGroups()))
 
 		cr := parquet.NewGenericReader[any](chunksFile)
 		n, err = cr.ReadRows(buf)

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -20,6 +20,8 @@ import (
 	"github.com/parquet-go/parquet-go"
 	"github.com/parquet-go/parquet-go/compress/zstd"
 	"github.com/parquet-go/parquet-go/format"
+
+	"github.com/prometheus-community/parquet-common/util"
 )
 
 const (
@@ -40,8 +42,7 @@ func ExtractLabelFromColumn(col string) (string, bool) {
 	if !strings.HasPrefix(col, LabelColumnPrefix) {
 		return "", false
 	}
-
-	return strings.TrimPrefix(col, LabelColumnPrefix), true
+	return util.YoloString([]byte(col)[len(LabelColumnPrefix):]), true
 }
 
 func IsDataColumn(col string) bool {

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -20,8 +20,6 @@ import (
 	"github.com/parquet-go/parquet-go"
 	"github.com/parquet-go/parquet-go/compress/zstd"
 	"github.com/parquet-go/parquet-go/format"
-
-	"github.com/prometheus-community/parquet-common/util"
 )
 
 const (
@@ -42,7 +40,7 @@ func ExtractLabelFromColumn(col string) (string, bool) {
 	if !strings.HasPrefix(col, LabelColumnPrefix) {
 		return "", false
 	}
-	return util.YoloString([]byte(col)[len(LabelColumnPrefix):]), true
+	return col[len(LabelColumnPrefix):], true
 }
 
 func IsDataColumn(col string) bool {

--- a/schema/schema_builder.go
+++ b/schema/schema_builder.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/efficientgo/core/errors"
 	"github.com/parquet-go/parquet-go"
 )
 
@@ -42,6 +43,44 @@ func NewBuilder(mint, maxt, colDuration int64) *Builder {
 	}
 
 	return b
+}
+
+func FromLabelsFile(lf *parquet.File) (*TSDBSchema, error) {
+	md := MetadataToMap(lf.Metadata().KeyValueMetadata)
+	mint, err := strconv.ParseInt(md[MinTMd], 0, 64)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to convert mint to int")
+	}
+
+	maxt, err := strconv.ParseInt(md[MaxTMd], 10, 64)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to convert max to int")
+	}
+
+	dataColDurationMs, err := strconv.ParseInt(md[DataColSizeMd], 10, 64)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to convert dataColDurationMs to int")
+	}
+	g := make(parquet.Group)
+
+	b := &Builder{
+		g:                 g,
+		metadata:          md,
+		mint:              mint,
+		maxt:              maxt,
+		dataColDurationMs: dataColDurationMs,
+	}
+
+	for _, c := range lf.Schema().Columns() {
+		lbl, ok := ExtractLabelFromColumn(c[0])
+		if !ok {
+			continue
+		}
+
+		b.AddLabelNameColumn(lbl)
+	}
+
+	return b.Build()
 }
 
 func (b *Builder) AddLabelNameColumn(lbls ...string) {

--- a/search/constraint.go
+++ b/search/constraint.go
@@ -79,6 +79,10 @@ func (s *symbolTable) Get(i int) parquet.Value {
 	}
 }
 
+func (s *symbolTable) GetIndex(i int) int32 {
+	return s.syms[i]
+}
+
 func (s *symbolTable) Reset(pg parquet.Page) {
 	dict := pg.Dictionary()
 	data := pg.Data()

--- a/search/constraint.go
+++ b/search/constraint.go
@@ -19,8 +19,9 @@ import (
 	"sort"
 
 	"github.com/parquet-go/parquet-go"
-	"github.com/prometheus-community/parquet-common/util"
 	"github.com/prometheus/prometheus/model/labels"
+
+	"github.com/prometheus-community/parquet-common/util"
 )
 
 func initialize(s *parquet.Schema, cs ...Constraint) error {
@@ -32,7 +33,7 @@ func initialize(s *parquet.Schema, cs ...Constraint) error {
 	return nil
 }
 
-func filter(rg parquet.RowGroup, cs ...Constraint) ([]rowRange, error) {
+func filter(rg parquet.RowGroup, cs ...Constraint) ([]RowRange, error) {
 	// Constraints for sorting columns are cheaper to evaluate, so we sort them first.
 	sc := rg.SortingColumns()
 
@@ -49,7 +50,7 @@ func filter(rg parquet.RowGroup, cs ...Constraint) ([]rowRange, error) {
 		}
 	}
 	var err error
-	rr := []rowRange{{from: int64(0), count: rg.NumRows()}}
+	rr := []RowRange{{from: int64(0), count: rg.NumRows()}}
 	for i := range cs {
 		isPrimary := len(sc) > 0 && cs[i].path() == sc[0].Path()[0]
 		rr, err = cs[i].filter(rg, isPrimary, rr)
@@ -119,7 +120,7 @@ func Equal(path string, value parquet.Value) Constraint {
 	return &equalConstraint{pth: path, val: value}
 }
 
-func (ec *equalConstraint) filter(rg parquet.RowGroup, primary bool, rr []rowRange) ([]rowRange, error) {
+func (ec *equalConstraint) filter(rg parquet.RowGroup, primary bool, rr []RowRange) ([]RowRange, error) {
 	if len(rr) == 0 {
 		return nil, nil
 	}
@@ -150,7 +151,7 @@ func (ec *equalConstraint) filter(rg parquet.RowGroup, primary bool, rr []rowRan
 	}
 	var (
 		symbols = new(symbolTable)
-		res     = make([]rowRange, 0)
+		res     = make([]RowRange, 0)
 	)
 	for i := 0; i < cidx.NumPages(); i++ {
 		// If page does not intersect from, to; we can immediately discard it
@@ -209,14 +210,14 @@ func (ec *equalConstraint) filter(rg parquet.RowGroup, primary bool, rr []rowRan
 			r = sort.Search(n, func(i int) bool { return ec.comp(ec.val, symbols.Get(i)) < 0 })
 
 			if lv, rv := max(bl, l), min(br, r); rv > lv {
-				res = append(res, rowRange{pfrom + int64(lv), int64(rv - lv)})
+				res = append(res, RowRange{pfrom + int64(lv), int64(rv - lv)})
 			}
 		default:
 			off, count := bl, 0
 			for j := bl; j < br; j++ {
 				if ec.comp(ec.val, symbols.Get(j)) != 0 {
 					if count != 0 {
-						res = append(res, rowRange{pfrom + int64(off), int64(count)})
+						res = append(res, RowRange{pfrom + int64(off), int64(count)})
 					}
 					off, count = j, 0
 				} else {
@@ -227,7 +228,7 @@ func (ec *equalConstraint) filter(rg parquet.RowGroup, primary bool, rr []rowRan
 				}
 			}
 			if count != 0 {
-				res = append(res, rowRange{pfrom + int64(off), int64(count)})
+				res = append(res, RowRange{pfrom + int64(off), int64(count)})
 			}
 		}
 	}
@@ -289,7 +290,7 @@ type regexConstraint struct {
 	r *labels.FastRegexMatcher
 }
 
-func (rc *regexConstraint) filter(rg parquet.RowGroup, primary bool, rr []rowRange) ([]rowRange, error) {
+func (rc *regexConstraint) filter(rg parquet.RowGroup, primary bool, rr []RowRange) ([]RowRange, error) {
 	if len(rr) == 0 {
 		return nil, nil
 	}
@@ -314,7 +315,7 @@ func (rc *regexConstraint) filter(rg parquet.RowGroup, primary bool, rr []rowRan
 	}
 	var (
 		symbols = new(symbolTable)
-		res     = make([]rowRange, 0)
+		res     = make([]RowRange, 0)
 	)
 	for i := 0; i < cidx.NumPages(); i++ {
 		// If page does not intersect from, to; we can immediately discard it
@@ -358,7 +359,7 @@ func (rc *regexConstraint) filter(rg parquet.RowGroup, primary bool, rr []rowRan
 		for j := bl; j < br; j++ {
 			if !rc.matches(symbols.Get(j)) {
 				if count != 0 {
-					res = append(res, rowRange{pfrom + int64(off), int64(count)})
+					res = append(res, RowRange{pfrom + int64(off), int64(count)})
 				}
 				off, count = j, 0
 			} else {
@@ -369,7 +370,7 @@ func (rc *regexConstraint) filter(rg parquet.RowGroup, primary bool, rr []rowRan
 			}
 		}
 		if count != 0 {
-			res = append(res, rowRange{pfrom + int64(off), int64(count)})
+			res = append(res, RowRange{pfrom + int64(off), int64(count)})
 		}
 	}
 	if len(res) == 0 {
@@ -423,7 +424,7 @@ type notConstraint struct {
 	c Constraint
 }
 
-func (nc *notConstraint) filter(rg parquet.RowGroup, primary bool, rr []rowRange) ([]rowRange, error) {
+func (nc *notConstraint) filter(rg parquet.RowGroup, primary bool, rr []RowRange) ([]RowRange, error) {
 	base, err := nc.c.filter(rg, primary, rr)
 	if err != nil {
 		return nil, fmt.Errorf("unable to compute child constraint: %w", err)
@@ -446,7 +447,7 @@ func Null() Constraint {
 	return &nullConstraint{}
 }
 
-func (null *nullConstraint) filter(parquet.RowGroup, bool, []rowRange) ([]rowRange, error) {
+func (null *nullConstraint) filter(parquet.RowGroup, bool, []RowRange) ([]RowRange, error) {
 	return nil, nil
 }
 

--- a/search/constraint_test.go
+++ b/search/constraint_test.go
@@ -52,7 +52,7 @@ func mustNewFastRegexMatcher(t *testing.T, s string) *labels.FastRegexMatcher {
 func TestFilter(t *testing.T) {
 	type expectation struct {
 		constraints []Constraint
-		expect      []rowRange
+		expect      []RowRange
 	}
 	type testcase[T any] struct {
 		rows         []T
@@ -83,7 +83,7 @@ func TestFilter(t *testing.T) {
 							Equal("A", parquet.ValueOf(7)),
 							Equal("C", parquet.ValueOf("g")),
 						},
-						expect: []rowRange{
+						expect: []RowRange{
 							{from: 6, count: 1},
 						},
 					},
@@ -91,7 +91,7 @@ func TestFilter(t *testing.T) {
 						constraints: []Constraint{
 							Equal("A", parquet.ValueOf(7)),
 						},
-						expect: []rowRange{
+						expect: []RowRange{
 							{from: 2, count: 1},
 							{from: 5, count: 2},
 						},
@@ -100,7 +100,7 @@ func TestFilter(t *testing.T) {
 						constraints: []Constraint{
 							Equal("A", parquet.ValueOf(7)), Not(Equal("B", parquet.ValueOf(1))),
 						},
-						expect: []rowRange{
+						expect: []RowRange{
 							{from: 2, count: 1},
 						},
 					},
@@ -108,7 +108,7 @@ func TestFilter(t *testing.T) {
 						constraints: []Constraint{
 							Equal("A", parquet.ValueOf(7)), Not(Equal("C", parquet.ValueOf("c"))),
 						},
-						expect: []rowRange{
+						expect: []RowRange{
 							{from: 5, count: 2},
 						},
 					},
@@ -116,7 +116,7 @@ func TestFilter(t *testing.T) {
 						constraints: []Constraint{
 							Not(Equal("A", parquet.ValueOf(227))),
 						},
-						expect: []rowRange{
+						expect: []RowRange{
 							{from: 0, count: 8},
 						},
 					},
@@ -124,7 +124,7 @@ func TestFilter(t *testing.T) {
 						constraints: []Constraint{
 							Regex("C", mustNewFastRegexMatcher(t, "a|c|d")),
 						},
-						expect: []rowRange{
+						expect: []RowRange{
 							{from: 0, count: 1},
 							{from: 2, count: 2},
 						},
@@ -151,7 +151,7 @@ func TestFilter(t *testing.T) {
 						constraints: []Constraint{
 							Not(Equal("A", parquet.ValueOf(3))),
 						},
-						expect: []rowRange{
+						expect: []RowRange{
 							{from: 0, count: 9},
 						},
 					},
@@ -160,7 +160,7 @@ func TestFilter(t *testing.T) {
 							Not(Equal("A", parquet.ValueOf(3))),
 							Equal("B", parquet.ValueOf(5)),
 						},
-						expect: []rowRange{
+						expect: []RowRange{
 							{from: 4, count: 5},
 						},
 					},
@@ -169,7 +169,7 @@ func TestFilter(t *testing.T) {
 							Not(Equal("A", parquet.ValueOf(3))),
 							Not(Equal("A", parquet.ValueOf(1))),
 						},
-						expect: []rowRange{
+						expect: []RowRange{
 							{from: 6, count: 3},
 						},
 					},
@@ -178,21 +178,21 @@ func TestFilter(t *testing.T) {
 							Equal("A", parquet.ValueOf(2)),
 							Not(Equal("B", parquet.ValueOf(5))),
 						},
-						expect: []rowRange{},
+						expect: []RowRange{},
 					},
 					{
 						constraints: []Constraint{
 							Equal("A", parquet.ValueOf(2)),
 							Not(Equal("B", parquet.ValueOf(5))),
 						},
-						expect: []rowRange{},
+						expect: []RowRange{},
 					},
 					{
 						constraints: []Constraint{
 							Equal("A", parquet.ValueOf(3)),
 							Not(Equal("B", parquet.ValueOf(2))),
 						},
-						expect: []rowRange{
+						expect: []RowRange{
 							{from: 9, count: 2},
 						},
 					},
@@ -215,7 +215,7 @@ func TestFilter(t *testing.T) {
 							Not(Equal("A", parquet.ValueOf(1))),
 							Not(Equal("B", parquet.ValueOf(2))),
 						},
-						expect: []rowRange{
+						expect: []RowRange{
 							{from: 2, count: 1},
 							{from: 6, count: 1},
 						},
@@ -234,7 +234,7 @@ func TestFilter(t *testing.T) {
 						constraints: []Constraint{
 							Regex("C", mustNewFastRegexMatcher(t, "f.*")),
 						},
-						expect: []rowRange{
+						expect: []RowRange{
 							{from: 0, count: 1},
 							{from: 2, count: 1},
 						},
@@ -243,7 +243,7 @@ func TestFilter(t *testing.T) {
 						constraints: []Constraint{
 							Regex("C", mustNewFastRegexMatcher(t, "b.*")),
 						},
-						expect: []rowRange{
+						expect: []RowRange{
 							{from: 1, count: 1},
 							{from: 3, count: 1},
 						},
@@ -252,7 +252,7 @@ func TestFilter(t *testing.T) {
 						constraints: []Constraint{
 							Regex("C", mustNewFastRegexMatcher(t, "f.*|b.*")),
 						},
-						expect: []rowRange{
+						expect: []RowRange{
 							{from: 0, count: 4},
 						},
 					},
@@ -272,7 +272,7 @@ func TestFilter(t *testing.T) {
 							Equal("A", parquet.ValueOf(1)),
 							Equal("B", parquet.ValueOf(1)),
 						},
-						expect: []rowRange{
+						expect: []RowRange{
 							{from: 0, count: 1},
 							{from: 4, count: 1},
 						},

--- a/search/materialize.go
+++ b/search/materialize.go
@@ -1,0 +1,320 @@
+package search
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"runtime"
+	"slices"
+	"sort"
+
+	"github.com/efficientgo/core/errors"
+	"github.com/parquet-go/parquet-go"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/storage"
+	"github.com/prometheus/prometheus/tsdb/chunks"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/prometheus-community/parquet-common/schema"
+	"github.com/prometheus-community/parquet-common/util"
+)
+
+type Materializer struct {
+	lf *parquet.File
+	cf *parquet.File
+	s  *schema.TSDBSchema
+	d  *schema.PrometheusParquetChunksDecoder
+
+	colIdx      int
+	concurrency int
+
+	dataColToIndex []int
+}
+
+func NewMaterializer(s *schema.TSDBSchema, d *schema.PrometheusParquetChunksDecoder, lf, cf *parquet.File) (*Materializer, error) {
+	colIdx, ok := lf.Schema().Lookup(schema.ColIndexes)
+	if !ok {
+		return nil, errors.New(fmt.Sprintf("schema index %s not found", schema.ColIndexes))
+	}
+
+	dataColToIndex := make([]int, len(cf.Schema().Columns()))
+	for i := 0; i < len(s.DataColsIndexes); i++ {
+		c, ok := cf.Schema().Lookup(schema.DataColumn(i))
+		if !ok {
+			return nil, errors.New(fmt.Sprintf("schema column %s not found", schema.DataColumn(i)))
+		}
+
+		dataColToIndex[i] = c.ColumnIndex
+	}
+
+	return &Materializer{
+		s:              s,
+		d:              d,
+		lf:             lf,
+		cf:             cf,
+		colIdx:         colIdx.ColumnIndex,
+		concurrency:    runtime.GOMAXPROCS(0),
+		dataColToIndex: dataColToIndex,
+	}, nil
+}
+
+// Materialize reconstructs the ChunkSeries that belong to the specified row ranges (rr).
+// It uses the row group index (rgi) and time bounds (mint, maxt) to filter and decode the series.
+func (m *Materializer) Materialize(ctx context.Context, rgi int, mint, maxt int64, rr []rowRange) ([]storage.ChunkSeries, error) {
+	labelsRg := m.lf.RowGroups()[rgi]
+	cc := labelsRg.ColumnChunks()[m.colIdx]
+	colsIdxs, err := m.materializeColumn(ctx, labelsRg, cc, rr)
+	if err != nil {
+		return nil, errors.Wrap(err, "materializer failed to materialize columns")
+	}
+
+	colsMap := make(map[int]struct{}, 10)
+
+	results := make([]storage.ChunkSeries, len(colsIdxs))
+	for i := 0; i < len(colsIdxs); i++ {
+		results[i] = &concreteChunksSeries{}
+	}
+
+	for _, colsIdx := range colsIdxs {
+		idxs, err := schema.DecodeUintSlice(colsIdx.ByteArray())
+		if err != nil {
+			return nil, errors.Wrap(err, "materializer failed to decode column index")
+		}
+		for _, idx := range idxs {
+			colsMap[idx] = struct{}{}
+		}
+	}
+
+	for cIdx := range colsMap {
+		cc := labelsRg.ColumnChunks()[cIdx]
+		labelName, ok := schema.ExtractLabelFromColumn(m.lf.Schema().Columns()[cIdx][0])
+		if !ok {
+			return nil, fmt.Errorf("column %d not found in schema", cIdx)
+		}
+
+		values, err := m.materializeColumn(ctx, labelsRg, cc, rr)
+		if err != nil {
+			return nil, errors.Wrap(err, "materializer failed to materialize values")
+		}
+
+		for i, value := range values {
+			if value.IsNull() {
+				continue
+			}
+			results[i].(*concreteChunksSeries).lbls = append(results[i].(*concreteChunksSeries).lbls, labels.Label{
+				Name:  labelName,
+				Value: value.String(),
+			})
+		}
+	}
+
+	chks, err := m.materializeChunks(ctx, rgi, mint, maxt, rr)
+	if err != nil {
+		return nil, errors.Wrap(err, "materializer failed to materialize chunks")
+	}
+
+	for i, result := range results {
+		sort.Sort(result.(*concreteChunksSeries).lbls)
+		result.(*concreteChunksSeries).chks = chks[i]
+	}
+
+	return results, err
+}
+
+func (m *Materializer) materializeChunks(ctx context.Context, rgi int, mint, maxt int64, rr []rowRange) ([][]chunks.Meta, error) {
+	minDataCol := m.s.DataColumIdx(mint)
+	maxDataCol := m.s.DataColumIdx(maxt)
+	rg := m.cf.RowGroups()[rgi]
+	totalRows := int64(0)
+	for _, r := range rr {
+		totalRows += r.count
+	}
+	r := make([][]chunks.Meta, totalRows)
+
+	for i := minDataCol; i <= maxDataCol; i++ {
+		values, err := m.materializeColumn(ctx, rg, rg.ColumnChunks()[m.dataColToIndex[i]], rr)
+		if err != nil {
+			return r, err
+		}
+
+		for vi, value := range values {
+			chks, err := m.d.Decode(value.ByteArray(), mint, maxt)
+			if err != nil {
+				return r, errors.Wrap(err, "failed to decode chunks")
+			}
+			r[vi] = append(r[vi], chks...)
+		}
+	}
+
+	return r, nil
+}
+
+func (m *Materializer) materializeColumn(ctx context.Context, group parquet.RowGroup, cc parquet.ColumnChunk, rr []rowRange) ([]parquet.Value, error) {
+	if len(rr) == 0 {
+		return nil, nil
+	}
+
+	oidx, err := cc.OffsetIndex()
+	if err != nil {
+		return nil, errors.Wrap(err, "could not get offset index")
+	}
+
+	cidx, err := cc.ColumnIndex()
+	if err != nil {
+		return nil, errors.Wrap(err, "could not get column index")
+	}
+
+	pagesToRowsMap := make(map[int][]rowRange, len(rr))
+
+	for i := 0; i < cidx.NumPages(); i++ {
+		pageRowRange := rowRange{
+			from: oidx.FirstRowIndex(i),
+		}
+		pageRowRange.count = group.NumRows()
+
+		if i < oidx.NumPages()-1 {
+			pageRowRange.count = oidx.FirstRowIndex(i+1) - pageRowRange.from
+		}
+
+		for _, r := range rr {
+			if pageRowRange.Overlaps(r) {
+				pagesToRowsMap[i] = append(pagesToRowsMap[i], r)
+			}
+		}
+	}
+
+	r := make(map[rowRange][]parquet.Value, len(rr))
+	for _, v := range rr {
+		r[v] = []parquet.Value{}
+	}
+
+	errGroup := &errgroup.Group{}
+	errGroup.SetLimit(m.concurrency)
+
+	for _, p := range coalescePageRanges(pagesToRowsMap, oidx) {
+		errGroup.Go(func() error {
+			pgs := m.getPage(ctx, cc)
+			defer func() { _ = pgs.Close() }()
+			err := pgs.SeekToRow(p.rows[0].from)
+			if err != nil {
+				return errors.Wrap(err, "could not seek to row")
+			}
+
+			remainingRr := p.rows
+
+			currentRr := remainingRr[0]
+			next := currentRr.from
+			remaining := currentRr.count
+			currentRow := currentRr.from
+
+			remainingRr = remainingRr[1:]
+			for len(remainingRr) > 0 || remaining > 0 {
+				page, err := pgs.ReadPage()
+				if err != nil {
+					return errors.Wrap(err, "could not read page")
+				}
+
+				vr := page.Values()
+				for {
+					values := [1024]parquet.Value{}
+					n, err := vr.ReadValues(values[:])
+					if err != nil && err != io.EOF {
+						parquet.Release(page)
+						return err
+					}
+
+					for _, value := range values[:n] {
+						if currentRow == next {
+							r[currentRr] = append(r[currentRr], value.Clone())
+							remaining--
+							if remaining > 0 {
+								next = next + 1
+							} else if len(remainingRr) > 0 {
+								currentRr = remainingRr[0]
+								next = currentRr.from
+								remaining = currentRr.count
+								remainingRr = remainingRr[1:]
+							}
+						}
+						currentRow++
+					}
+
+					if err == io.EOF {
+						parquet.Release(page)
+						break
+					}
+				}
+			}
+			return nil
+		})
+	}
+	err = errGroup.Wait()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to materialize columns")
+	}
+
+	values := make([]parquet.Value, 0, 1024)
+	for _, v := range rr {
+		values = append(values, r[v]...)
+	}
+	return values, err
+}
+
+func (pr *Materializer) getPage(_ context.Context, cc parquet.ColumnChunk) *parquet.FilePages {
+	// TODO: pass the context to the reader
+	colChunk := cc.(*parquet.FileColumnChunk)
+	pages := colChunk.PagesFrom(colChunk.File())
+	return pages
+}
+
+type pageEntryRead struct {
+	pages []int
+	rows  []rowRange
+}
+
+// Merge nearby pages to enable efficient sequential reads.
+// Pages that are not close to each other will be scheduled for concurrent reads.
+func coalescePageRanges(pagedIdx map[int][]rowRange, offset parquet.OffsetIndex) []pageEntryRead {
+	partitioner := util.NewGapBasedPartitioner(10 * 1024)
+	if len(pagedIdx) == 0 {
+		return []pageEntryRead{}
+	}
+	idxs := make([]int, 0, len(pagedIdx))
+	for idx := range pagedIdx {
+		idxs = append(idxs, idx)
+	}
+
+	slices.Sort(idxs)
+
+	parts := partitioner.Partition(len(idxs), func(i int) (uint64, uint64) {
+		return uint64(offset.Offset(idxs[i])), uint64(offset.Offset(idxs[i]) + offset.CompressedPageSize(idxs[i]))
+	})
+
+	r := make([]pageEntryRead, 0, len(parts))
+	for _, part := range parts {
+		pagesToRead := pageEntryRead{}
+		for i := part.ElemRng[0]; i < part.ElemRng[1]; i++ {
+			pagesToRead.pages = append(pagesToRead.pages, idxs[i])
+			pagesToRead.rows = append(pagesToRead.rows, pagedIdx[idxs[i]]...)
+		}
+		pagesToRead.rows = simplify(pagesToRead.rows)
+		r = append(r, pagesToRead)
+	}
+
+	return r
+}
+
+var _ storage.ChunkSeries = &concreteChunksSeries{}
+
+type concreteChunksSeries struct {
+	lbls labels.Labels
+	chks []chunks.Meta
+}
+
+func (c concreteChunksSeries) Labels() labels.Labels {
+	return c.lbls
+}
+
+func (c concreteChunksSeries) Iterator(_ chunks.Iterator) chunks.Iterator {
+	return storage.NewListChunkSeriesIterator(c.chks...)
+}

--- a/search/materialize.go
+++ b/search/materialize.go
@@ -151,7 +151,7 @@ func (m *Materializer) materializeLabels(ctx context.Context, rgi int, rr []rowR
 			}
 			results[i] = append(results[i], labels.Label{
 				Name:  labelName,
-				Value: util.YoloString(value.ByteArray()),
+				Value: value.String(),
 			})
 		}
 	}

--- a/search/materialize.go
+++ b/search/materialize.go
@@ -1,3 +1,16 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package search
 
 import (

--- a/search/materialize.go
+++ b/search/materialize.go
@@ -336,7 +336,7 @@ func coalescePageRanges(pagedIdx map[int][]rowRange, offset parquet.OffsetIndex)
 type valuesIterator struct {
 	p parquet.Page
 
-	//TODO: consider using unique.Handle
+	// TODO: consider using unique.Handle
 	cachedSymbols map[int32]parquet.Value
 	st            symbolTable
 

--- a/search/materialize_test.go
+++ b/search/materialize_test.go
@@ -1,0 +1,149 @@
+package search
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/parquet-go/parquet-go"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/storage"
+	"github.com/prometheus/prometheus/tsdb/chunkenc"
+	"github.com/prometheus/prometheus/util/teststorage"
+	"github.com/stretchr/testify/require"
+	"github.com/thanos-io/objstore/providers/filesystem"
+
+	"github.com/prometheus-community/parquet-common/convert"
+	"github.com/prometheus-community/parquet-common/schema"
+	"github.com/prometheus-community/parquet-common/util"
+)
+
+func TestMaterializeE2E(t *testing.T) {
+	st := teststorage.New(t)
+	ctx := context.Background()
+	t.Cleanup(func() { _ = st.Close() })
+
+	bkt, err := filesystem.NewBucket(t.TempDir())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = bkt.Close() })
+
+	app := st.Appender(ctx)
+	seriesHash := make(map[uint64]*struct{})
+	totalMetricNames := 10
+	metricsPerMetricsName := 20
+	numberOfLabels := 5
+	randomLabels := 3
+	numberOfSamples := 250
+
+	builder := labels.NewScratchBuilder(numberOfLabels)
+
+	for i := 0; i < totalMetricNames; i++ {
+		for n := 0; n < metricsPerMetricsName; n++ {
+			builder.Reset()
+			builder.Add(labels.MetricName, fmt.Sprintf("metric_%d", i))
+			builder.Add("unique", fmt.Sprintf("unique_%d", n))
+
+			for j := 0; j < numberOfLabels; j++ {
+				builder.Add(fmt.Sprintf("label_name_%v", j), fmt.Sprintf("label_value_%v", j))
+			}
+
+			firstRandom := rand.Int() % 10
+			for k := firstRandom; k < firstRandom+randomLabels; k++ {
+				builder.Add(fmt.Sprintf("randon_name_%v", k), fmt.Sprintf("randon_value_%v", k))
+			}
+
+			builder.Sort()
+			lbls := builder.Labels()
+			seriesHash[lbls.Hash()] = &struct{}{}
+			for s := 0; s < numberOfSamples; s++ {
+				_, err := app.Append(0, lbls, (1 * time.Minute * time.Duration(s)).Milliseconds(), float64(i))
+				require.NoError(t, err)
+			}
+		}
+	}
+
+	require.NoError(t, app.Commit())
+
+	h := st.Head()
+	shards, err := convert.ConvertTSDBBlock(
+		ctx,
+		bkt,
+		h.MinTime(),
+		h.MaxTime(),
+		[]convert.Convertible{h},
+		convert.WithName("block"),
+		convert.WithColDuration(time.Hour), // lets force more than 1 data col
+		convert.WithRowGroupSize(500),
+		convert.WithPageBufferSize(300), // force create multiples pages
+	)
+
+	require.NoError(t, err)
+	require.Equal(t, 1, shards)
+
+	labelsFileName := schema.LabelsPfileNameForShard("block", 0)
+	chunksFileName := schema.ChunksPfileNameForShard("block", 0)
+	lf, cf, err := util.OpenParquetFiles(ctx, bkt, labelsFileName, chunksFileName)
+	require.NoError(t, err)
+
+	// Query by unique label (not sorted label)
+	eq := Equal(schema.LabelToColumn("unique"), parquet.ValueOf("unique_0"))
+	found := query(t, eq, h.MinTime(), h.MaxTime(), lf, cf)
+	require.Len(t, found, totalMetricNames)
+
+	for _, series := range found {
+		require.Equal(t, series.Labels().Get("unique"), "unique_0")
+		require.Contains(t, seriesHash, series.Labels().Hash())
+	}
+
+	// Query some random metric name
+	for i := 0; i < 50; i++ {
+		name := fmt.Sprintf("metric_%d", rand.Int()%totalMetricNames)
+		eq := Equal(schema.LabelToColumn(labels.MetricName), parquet.ValueOf(name))
+
+		found := query(t, eq, h.MinTime(), h.MaxTime(), lf, cf)
+
+		require.Len(t, found, metricsPerMetricsName, fmt.Sprintf("metric_%d", i))
+
+		for _, series := range found {
+			require.Equal(t, series.Labels().Get(labels.MetricName), name)
+			require.Contains(t, seriesHash, series.Labels().Hash())
+
+			totalSamples := 0
+			ci := series.Iterator(nil)
+			for ci.Next() {
+				si := ci.At().Chunk.Iterator(nil)
+				for si.Next() != chunkenc.ValNone {
+					totalSamples++
+				}
+			}
+			require.Equal(t, totalSamples, numberOfSamples)
+		}
+	}
+}
+
+func query(t *testing.T, c Constraint, mint, maxt int64, lf, cf *parquet.File) []storage.ChunkSeries {
+	ctx := context.Background()
+	require.NoError(t, c.init(lf.Schema()))
+	s, err := schema.FromLabelsFile(lf)
+	require.NoError(t, err)
+	d := schema.NewPrometheusParquetChunksDecoder(chunkenc.NewPool())
+	m, err := NewMaterializer(s, d, lf, cf)
+	require.NoError(t, err)
+
+	found := make([]storage.ChunkSeries, 0, 100)
+	for i, group := range lf.RowGroups() {
+		rr, err := filter(group, c)
+		total := int64(0)
+		for _, r := range rr {
+			total += r.count
+		}
+		require.NoError(t, err)
+		series, err := m.Materialize(ctx, i, mint, maxt, rr)
+		require.NoError(t, err)
+		require.Len(t, series, int(total))
+		found = append(found, series...)
+	}
+	return found
+}

--- a/search/materialize_test.go
+++ b/search/materialize_test.go
@@ -1,3 +1,16 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package search
 
 import (

--- a/search/rowrange.go
+++ b/search/rowrange.go
@@ -17,14 +17,21 @@ import (
 	"sort"
 )
 
-type rowRange struct {
+type RowRange struct {
 	from  int64
 	count int64
 }
 
-// Overlaps returns true if the receiver and the given rowRange share any overlapping rows.
+func NewRowRange(from, count int64) *RowRange {
+	return &RowRange{
+		from:  from,
+		count: count,
+	}
+}
+
+// Overlaps returns true if the receiver and the given RowRange share any overlapping rows.
 // Both ranges are treated as half-open intervals: [from, from+count).
-func (rr rowRange) Overlaps(o rowRange) bool {
+func (rr RowRange) Overlaps(o RowRange) bool {
 	endA := rr.from + rr.count
 	endB := o.from + o.count
 	return rr.from < endB && o.from < endA
@@ -33,8 +40,8 @@ func (rr rowRange) Overlaps(o rowRange) bool {
 // intersect intersects the row ranges from left hand sight with the row ranges from rhs
 // it assumes that lhs and rhs are simplified and returns a simplified result.
 // it operates in o(l+r) time by cursoring through ranges with a two pointer approach.
-func intersectRowRanges(lhs, rhs []rowRange) []rowRange {
-	res := make([]rowRange, 0)
+func intersectRowRanges(lhs, rhs []RowRange) []RowRange {
+	res := make([]RowRange, 0)
 	for l, r := 0, 0; l < len(lhs) && r < len(rhs); {
 		al, bl := lhs[l].from, lhs[l].from+lhs[l].count
 		ar, br := rhs[r].from, rhs[r].from+rhs[r].count
@@ -42,7 +49,7 @@ func intersectRowRanges(lhs, rhs []rowRange) []rowRange {
 		// check if rows intersect
 		if al <= br && ar <= bl {
 			os, oe := max(al, ar), min(bl, br)
-			res = append(res, rowRange{from: os, count: oe - os})
+			res = append(res, RowRange{from: os, count: oe - os})
 		}
 
 		// advance the cursor of the range that ends first
@@ -65,8 +72,8 @@ func intersectRowRanges(lhs, rhs []rowRange) []rowRange {
 // The function assumes that lhs and rhs are simplified (no overlapping ranges)
 // and returns a simplified result. It operates in O(l+r) time by using a two-pointer approach
 // to efficiently process both ranges.
-func complementRowRanges(lhs, rhs []rowRange) []rowRange {
-	res := make([]rowRange, 0)
+func complementRowRanges(lhs, rhs []RowRange) []RowRange {
+	res := make([]RowRange, 0)
 
 	l, r := 0, 0
 	for l < len(lhs) && r < len(rhs) {
@@ -80,7 +87,7 @@ func complementRowRanges(lhs, rhs []rowRange) []rowRange {
 			if bl <= br {
 				l++
 			} else {
-				res = append(res, rowRange{from: ar, count: br - ar})
+				res = append(res, RowRange{from: ar, count: br - ar})
 				r++
 			}
 		case al < ar && bl > br:
@@ -95,12 +102,12 @@ func complementRowRanges(lhs, rhs []rowRange) []rowRange {
 		case al >= ar && bl > br:
 			// l covers r from right but has room on bottom
 			os := max(al, ar)
-			res = append(res, rowRange{from: ar, count: os - ar})
+			res = append(res, RowRange{from: ar, count: os - ar})
 			r++
 		case al >= ar && bl <= br:
 			// l is included r
 			os, oe := max(al, ar), min(bl, br)
-			res = append(res, rowRange{from: rhs[r].from, count: os - rhs[r].from})
+			res = append(res, RowRange{from: rhs[r].from, count: os - rhs[r].from})
 			rhs[r].from = oe
 			rhs[r].count = br - oe
 			l++
@@ -114,7 +121,7 @@ func complementRowRanges(lhs, rhs []rowRange) []rowRange {
 	return simplify(res)
 }
 
-func simplify(rr []rowRange) []rowRange {
+func simplify(rr []RowRange) []RowRange {
 	if len(rr) == 0 {
 		return nil
 	}
@@ -123,7 +130,7 @@ func simplify(rr []rowRange) []rowRange {
 		return rr[i].from < rr[j].from
 	})
 
-	tmp := make([]rowRange, 0)
+	tmp := make([]RowRange, 0)
 	l := rr[0]
 	for i := 1; i < len(rr); i++ {
 		r := rr[i]
@@ -141,14 +148,14 @@ func simplify(rr []rowRange) []rowRange {
 			continue
 		}
 
-		l = rowRange{
+		l = RowRange{
 			from:  from,
 			count: count,
 		}
 	}
 
 	tmp = append(tmp, l)
-	res := make([]rowRange, 0, len(tmp))
+	res := make([]RowRange, 0, len(tmp))
 	for i := range tmp {
 		if tmp[i].count != 0 {
 			res = append(res, tmp[i])

--- a/search/rowrange.go
+++ b/search/rowrange.go
@@ -22,6 +22,14 @@ type rowRange struct {
 	count int64
 }
 
+// Overlaps returns true if the receiver and the given rowRange share any overlapping rows.
+// Both ranges are treated as half-open intervals: [from, from+count).
+func (rr rowRange) Overlaps(o rowRange) bool {
+	endA := rr.from + rr.count
+	endB := o.from + o.count
+	return rr.from < endB && o.from < endA
+}
+
 // intersect intersects the row ranges from left hand sight with the row ranges from rhs
 // it assumes that lhs and rhs are simplified and returns a simplified result.
 // it operates in o(l+r) time by cursoring through ranges with a two pointer approach.

--- a/search/rowrange_test.go
+++ b/search/rowrange_test.go
@@ -19,66 +19,66 @@ import (
 )
 
 func TestIntersect(t *testing.T) {
-	for _, tt := range []struct{ lhs, rhs, expect []rowRange }{
+	for _, tt := range []struct{ lhs, rhs, expect []RowRange }{
 		{
-			lhs:    []rowRange{{from: 0, count: 4}},
-			rhs:    []rowRange{{from: 2, count: 6}},
-			expect: []rowRange{{from: 2, count: 2}},
+			lhs:    []RowRange{{from: 0, count: 4}},
+			rhs:    []RowRange{{from: 2, count: 6}},
+			expect: []RowRange{{from: 2, count: 2}},
 		},
 		{
-			lhs:    []rowRange{{from: 0, count: 4}},
-			rhs:    []rowRange{{from: 6, count: 8}},
-			expect: []rowRange{},
+			lhs:    []RowRange{{from: 0, count: 4}},
+			rhs:    []RowRange{{from: 6, count: 8}},
+			expect: []RowRange{},
 		},
 		{
-			lhs:    []rowRange{{from: 0, count: 4}},
-			rhs:    []rowRange{{from: 0, count: 4}},
-			expect: []rowRange{{from: 0, count: 4}},
+			lhs:    []RowRange{{from: 0, count: 4}},
+			rhs:    []RowRange{{from: 0, count: 4}},
+			expect: []RowRange{{from: 0, count: 4}},
 		},
 		{
-			lhs:    []rowRange{{from: 0, count: 4}, {from: 8, count: 2}},
-			rhs:    []rowRange{{from: 2, count: 9}},
-			expect: []rowRange{{from: 2, count: 2}, {from: 8, count: 2}},
+			lhs:    []RowRange{{from: 0, count: 4}, {from: 8, count: 2}},
+			rhs:    []RowRange{{from: 2, count: 9}},
+			expect: []RowRange{{from: 2, count: 2}, {from: 8, count: 2}},
 		},
 		{
-			lhs:    []rowRange{{from: 0, count: 1}, {from: 4, count: 1}},
-			rhs:    []rowRange{{from: 2, count: 1}, {from: 6, count: 1}},
-			expect: []rowRange{},
+			lhs:    []RowRange{{from: 0, count: 1}, {from: 4, count: 1}},
+			rhs:    []RowRange{{from: 2, count: 1}, {from: 6, count: 1}},
+			expect: []RowRange{},
 		},
 		{
-			lhs:    []rowRange{{from: 0, count: 2}, {from: 2, count: 2}},
-			rhs:    []rowRange{{from: 1, count: 2}, {from: 3, count: 2}},
-			expect: []rowRange{{from: 1, count: 3}},
+			lhs:    []RowRange{{from: 0, count: 2}, {from: 2, count: 2}},
+			rhs:    []RowRange{{from: 1, count: 2}, {from: 3, count: 2}},
+			expect: []RowRange{{from: 1, count: 3}},
 		},
 		{
-			lhs:    []rowRange{{from: 0, count: 2}, {from: 5, count: 2}},
-			rhs:    []rowRange{{from: 0, count: 10}},
-			expect: []rowRange{{from: 0, count: 2}, {from: 5, count: 2}},
+			lhs:    []RowRange{{from: 0, count: 2}, {from: 5, count: 2}},
+			rhs:    []RowRange{{from: 0, count: 10}},
+			expect: []RowRange{{from: 0, count: 2}, {from: 5, count: 2}},
 		},
 		{
-			lhs:    []rowRange{{from: 0, count: 2}, {from: 3, count: 1}, {from: 5, count: 2}, {from: 12, count: 10}},
-			rhs:    []rowRange{{from: 0, count: 10}, {from: 15, count: 32}},
-			expect: []rowRange{{from: 0, count: 2}, {from: 3, count: 1}, {from: 5, count: 2}, {from: 15, count: 7}},
+			lhs:    []RowRange{{from: 0, count: 2}, {from: 3, count: 1}, {from: 5, count: 2}, {from: 12, count: 10}},
+			rhs:    []RowRange{{from: 0, count: 10}, {from: 15, count: 32}},
+			expect: []RowRange{{from: 0, count: 2}, {from: 3, count: 1}, {from: 5, count: 2}, {from: 15, count: 7}},
 		},
 		{
-			lhs:    []rowRange{},
-			rhs:    []rowRange{{from: 0, count: 10}},
-			expect: []rowRange{},
+			lhs:    []RowRange{},
+			rhs:    []RowRange{{from: 0, count: 10}},
+			expect: []RowRange{},
 		},
 		{
-			lhs:    []rowRange{{from: 0, count: 10}},
-			rhs:    []rowRange{},
-			expect: []rowRange{},
+			lhs:    []RowRange{{from: 0, count: 10}},
+			rhs:    []RowRange{},
+			expect: []RowRange{},
 		},
 		{
-			lhs:    []rowRange{},
-			rhs:    []rowRange{},
-			expect: []rowRange{},
+			lhs:    []RowRange{},
+			rhs:    []RowRange{},
+			expect: []RowRange{},
 		},
 		{
-			lhs:    []rowRange{{from: 0, count: 2}},
-			rhs:    []rowRange{{from: 0, count: 1}, {from: 1, count: 1}, {from: 2, count: 1}},
-			expect: []rowRange{{from: 0, count: 2}},
+			lhs:    []RowRange{{from: 0, count: 2}},
+			rhs:    []RowRange{{from: 0, count: 1}, {from: 1, count: 1}, {from: 2, count: 1}},
+			expect: []RowRange{{from: 0, count: 2}},
 		},
 	} {
 		t.Run("", func(t *testing.T) {
@@ -90,82 +90,82 @@ func TestIntersect(t *testing.T) {
 }
 
 func TestComplement(t *testing.T) {
-	for _, tt := range []struct{ lhs, rhs, expect []rowRange }{
+	for _, tt := range []struct{ lhs, rhs, expect []RowRange }{
 		{
-			lhs:    []rowRange{{from: 4, count: 3}},
-			rhs:    []rowRange{{from: 2, count: 1}, {from: 5, count: 2}},
-			expect: []rowRange{{from: 2, count: 1}},
+			lhs:    []RowRange{{from: 4, count: 3}},
+			rhs:    []RowRange{{from: 2, count: 1}, {from: 5, count: 2}},
+			expect: []RowRange{{from: 2, count: 1}},
 		},
 		{
-			lhs:    []rowRange{{from: 2, count: 4}},
-			rhs:    []rowRange{{from: 0, count: 7}},
-			expect: []rowRange{{from: 0, count: 2}, {from: 6, count: 1}},
+			lhs:    []RowRange{{from: 2, count: 4}},
+			rhs:    []RowRange{{from: 0, count: 7}},
+			expect: []RowRange{{from: 0, count: 2}, {from: 6, count: 1}},
 		},
 		{
-			lhs:    []rowRange{{from: 2, count: 4}},
-			rhs:    []rowRange{{from: 3, count: 7}},
-			expect: []rowRange{{from: 6, count: 4}},
+			lhs:    []RowRange{{from: 2, count: 4}},
+			rhs:    []RowRange{{from: 3, count: 7}},
+			expect: []RowRange{{from: 6, count: 4}},
 		},
 		{
-			lhs:    []rowRange{{from: 8, count: 10}},
-			rhs:    []rowRange{{from: 3, count: 7}},
-			expect: []rowRange{{from: 3, count: 5}},
+			lhs:    []RowRange{{from: 8, count: 10}},
+			rhs:    []RowRange{{from: 3, count: 7}},
+			expect: []RowRange{{from: 3, count: 5}},
 		},
 		{
-			lhs:    []rowRange{{from: 16, count: 10}},
-			rhs:    []rowRange{{from: 3, count: 7}},
-			expect: []rowRange{{from: 3, count: 7}},
+			lhs:    []RowRange{{from: 16, count: 10}},
+			rhs:    []RowRange{{from: 3, count: 7}},
+			expect: []RowRange{{from: 3, count: 7}},
 		},
 		{
-			lhs:    []rowRange{{from: 1, count: 2}, {from: 4, count: 2}},
-			rhs:    []rowRange{{from: 2, count: 2}, {from: 5, count: 8}},
-			expect: []rowRange{{from: 3, count: 1}, {from: 6, count: 7}},
+			lhs:    []RowRange{{from: 1, count: 2}, {from: 4, count: 2}},
+			rhs:    []RowRange{{from: 2, count: 2}, {from: 5, count: 8}},
+			expect: []RowRange{{from: 3, count: 1}, {from: 6, count: 7}},
 		},
 		// Empty input cases
 		{
-			lhs:    []rowRange{},
-			rhs:    []rowRange{{from: 1, count: 5}},
-			expect: []rowRange{{from: 1, count: 5}},
+			lhs:    []RowRange{},
+			rhs:    []RowRange{{from: 1, count: 5}},
+			expect: []RowRange{{from: 1, count: 5}},
 		},
 		{
-			lhs:    []rowRange{{from: 1, count: 5}},
-			rhs:    []rowRange{},
-			expect: []rowRange{},
+			lhs:    []RowRange{{from: 1, count: 5}},
+			rhs:    []RowRange{},
+			expect: []RowRange{},
 		},
 		{
-			lhs:    []rowRange{},
-			rhs:    []rowRange{},
-			expect: []rowRange{},
+			lhs:    []RowRange{},
+			rhs:    []RowRange{},
+			expect: []RowRange{},
 		},
 		// Adjacent ranges
 		{
-			lhs:    []rowRange{{from: 1, count: 3}},
-			rhs:    []rowRange{{from: 1, count: 3}, {from: 4, count: 2}},
-			expect: []rowRange{{from: 4, count: 2}},
+			lhs:    []RowRange{{from: 1, count: 3}},
+			rhs:    []RowRange{{from: 1, count: 3}, {from: 4, count: 2}},
+			expect: []RowRange{{from: 4, count: 2}},
 		},
 		// Ranges with gaps
 		{
-			lhs:    []rowRange{{from: 1, count: 2}, {from: 5, count: 2}},
-			rhs:    []rowRange{{from: 0, count: 8}},
-			expect: []rowRange{{from: 0, count: 1}, {from: 3, count: 2}, {from: 7, count: 1}},
+			lhs:    []RowRange{{from: 1, count: 2}, {from: 5, count: 2}},
+			rhs:    []RowRange{{from: 0, count: 8}},
+			expect: []RowRange{{from: 0, count: 1}, {from: 3, count: 2}, {from: 7, count: 1}},
 		},
 		// Zero-count ranges
 		{
-			lhs:    []rowRange{{from: 1, count: 0}},
-			rhs:    []rowRange{{from: 1, count: 5}},
-			expect: []rowRange{{from: 1, count: 5}},
+			lhs:    []RowRange{{from: 1, count: 0}},
+			rhs:    []RowRange{{from: 1, count: 5}},
+			expect: []RowRange{{from: 1, count: 5}},
 		},
 		// Completely disjoint ranges
 		{
-			lhs:    []rowRange{{from: 1, count: 2}},
-			rhs:    []rowRange{{from: 5, count: 2}},
-			expect: []rowRange{{from: 5, count: 2}},
+			lhs:    []RowRange{{from: 1, count: 2}},
+			rhs:    []RowRange{{from: 5, count: 2}},
+			expect: []RowRange{{from: 5, count: 2}},
 		},
 		// Multiple overlapping ranges
 		{
-			lhs:    []rowRange{{from: 1, count: 3}, {from: 4, count: 3}, {from: 8, count: 2}},
-			rhs:    []rowRange{{from: 0, count: 11}},
-			expect: []rowRange{{from: 0, count: 1}, {from: 7, count: 1}, {from: 10, count: 1}},
+			lhs:    []RowRange{{from: 1, count: 3}, {from: 4, count: 3}, {from: 8, count: 2}},
+			rhs:    []RowRange{{from: 0, count: 11}},
+			expect: []RowRange{{from: 0, count: 1}, {from: 7, count: 1}, {from: 10, count: 1}},
 		},
 	} {
 		t.Run("", func(t *testing.T) {
@@ -177,32 +177,32 @@ func TestComplement(t *testing.T) {
 }
 
 func TestSimplify(t *testing.T) {
-	for _, tt := range []struct{ in, expect []rowRange }{
+	for _, tt := range []struct{ in, expect []RowRange }{
 		{
-			in: []rowRange{
+			in: []RowRange{
 				{from: 0, count: 15},
 				{from: 4, count: 4},
 			},
-			expect: []rowRange{
+			expect: []RowRange{
 				{from: 0, count: 15},
 			},
 		},
 		{
-			in: []rowRange{
+			in: []RowRange{
 				{from: 4, count: 4},
 				{from: 4, count: 2},
 			},
-			expect: []rowRange{
+			expect: []RowRange{
 				{from: 4, count: 4},
 			},
 		},
 		{
-			in: []rowRange{
+			in: []RowRange{
 				{from: 0, count: 4},
 				{from: 1, count: 5},
 				{from: 8, count: 10},
 			},
-			expect: []rowRange{
+			expect: []RowRange{
 				{from: 0, count: 6},
 				{from: 8, count: 10},
 			},
@@ -218,60 +218,60 @@ func TestSimplify(t *testing.T) {
 
 func TestOverlaps(t *testing.T) {
 	for _, tt := range []struct {
-		a, b   rowRange
+		a, b   RowRange
 		expect bool
 	}{
 		// Identical ranges
 		{
-			a:      rowRange{from: 0, count: 5},
-			b:      rowRange{from: 0, count: 5},
+			a:      RowRange{from: 0, count: 5},
+			b:      RowRange{from: 0, count: 5},
 			expect: true,
 		},
 		// Completely disjoint ranges
 		{
-			a:      rowRange{from: 0, count: 3},
-			b:      rowRange{from: 5, count: 3},
+			a:      RowRange{from: 0, count: 3},
+			b:      RowRange{from: 5, count: 3},
 			expect: false,
 		},
 		// Adjacent ranges (should not overlap as ranges are half-open)
 		{
-			a:      rowRange{from: 0, count: 3},
-			b:      rowRange{from: 3, count: 3},
+			a:      RowRange{from: 0, count: 3},
+			b:      RowRange{from: 3, count: 3},
 			expect: false,
 		},
 		// One range completely contains the other
 		{
-			a:      rowRange{from: 0, count: 10},
-			b:      rowRange{from: 2, count: 5},
+			a:      RowRange{from: 0, count: 10},
+			b:      RowRange{from: 2, count: 5},
 			expect: true,
 		},
 		// Partial overlap from left
 		{
-			a:      rowRange{from: 0, count: 5},
-			b:      rowRange{from: 3, count: 5},
+			a:      RowRange{from: 0, count: 5},
+			b:      RowRange{from: 3, count: 5},
 			expect: true,
 		},
 		// Partial overlap from right
 		{
-			a:      rowRange{from: 3, count: 5},
-			b:      rowRange{from: 0, count: 5},
+			a:      RowRange{from: 3, count: 5},
+			b:      RowRange{from: 0, count: 5},
 			expect: true,
 		},
 		// Zero-count ranges
 		{
-			a:      rowRange{from: 0, count: 0},
-			b:      rowRange{from: 0, count: 5},
+			a:      RowRange{from: 0, count: 0},
+			b:      RowRange{from: 0, count: 5},
 			expect: false,
 		},
 		{
-			a:      rowRange{from: 0, count: 5},
-			b:      rowRange{from: 0, count: 0},
+			a:      RowRange{from: 0, count: 5},
+			b:      RowRange{from: 0, count: 0},
 			expect: false,
 		},
 		// Negative ranges (edge case)
 		{
-			a:      rowRange{from: -5, count: 5},
-			b:      rowRange{from: -3, count: 5},
+			a:      RowRange{from: -5, count: 5},
+			b:      RowRange{from: -3, count: 5},
 			expect: true,
 		},
 	} {

--- a/search/rowrange_test.go
+++ b/search/rowrange_test.go
@@ -215,3 +215,74 @@ func TestSimplify(t *testing.T) {
 		})
 	}
 }
+
+func TestOverlaps(t *testing.T) {
+	for _, tt := range []struct {
+		a, b   rowRange
+		expect bool
+	}{
+		// Identical ranges
+		{
+			a:      rowRange{from: 0, count: 5},
+			b:      rowRange{from: 0, count: 5},
+			expect: true,
+		},
+		// Completely disjoint ranges
+		{
+			a:      rowRange{from: 0, count: 3},
+			b:      rowRange{from: 5, count: 3},
+			expect: false,
+		},
+		// Adjacent ranges (should not overlap as ranges are half-open)
+		{
+			a:      rowRange{from: 0, count: 3},
+			b:      rowRange{from: 3, count: 3},
+			expect: false,
+		},
+		// One range completely contains the other
+		{
+			a:      rowRange{from: 0, count: 10},
+			b:      rowRange{from: 2, count: 5},
+			expect: true,
+		},
+		// Partial overlap from left
+		{
+			a:      rowRange{from: 0, count: 5},
+			b:      rowRange{from: 3, count: 5},
+			expect: true,
+		},
+		// Partial overlap from right
+		{
+			a:      rowRange{from: 3, count: 5},
+			b:      rowRange{from: 0, count: 5},
+			expect: true,
+		},
+		// Zero-count ranges
+		{
+			a:      rowRange{from: 0, count: 0},
+			b:      rowRange{from: 0, count: 5},
+			expect: false,
+		},
+		{
+			a:      rowRange{from: 0, count: 5},
+			b:      rowRange{from: 0, count: 0},
+			expect: false,
+		},
+		// Negative ranges (edge case)
+		{
+			a:      rowRange{from: -5, count: 5},
+			b:      rowRange{from: -3, count: 5},
+			expect: true,
+		},
+	} {
+		t.Run("", func(t *testing.T) {
+			if res := tt.a.Overlaps(tt.b); res != tt.expect {
+				t.Fatalf("Expected %v.Overlaps(%v) to be %v, got %v", tt.a, tt.b, tt.expect, res)
+			}
+			// Test symmetry
+			if res := tt.b.Overlaps(tt.a); res != tt.expect {
+				t.Fatalf("Expected %v.Overlaps(%v) to be %v, got %v", tt.b, tt.a, tt.expect, res)
+			}
+		})
+	}
+}

--- a/search/search.go
+++ b/search/search.go
@@ -19,7 +19,7 @@ import (
 
 type Constraint interface {
 	// filter returns a set of non-overlapping increasing row indexes that may satisfy the constraint.
-	filter(rg parquet.RowGroup, primary bool, rr []rowRange) ([]rowRange, error)
+	filter(rg parquet.RowGroup, primary bool, rr []RowRange) ([]RowRange, error)
 	// init initializes the constraint with respect to the file schema and projections.
 	init(s *parquet.Schema) error
 	// path is the path for the column that is constrained

--- a/util/bucket_read_at.go
+++ b/util/bucket_read_at.go
@@ -1,3 +1,16 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package util
 
 import (

--- a/util/util.go
+++ b/util/util.go
@@ -3,7 +3,9 @@ package util
 import (
 	"unsafe"
 
+	"context"
 	"github.com/parquet-go/parquet-go"
+	"github.com/thanos-io/objstore"
 )
 
 func CloneRows(rows []parquet.Row) []parquet.Row {
@@ -16,4 +18,85 @@ func CloneRows(rows []parquet.Row) []parquet.Row {
 
 func YoloString(buf []byte) string {
 	return *((*string)(unsafe.Pointer(&buf)))
+}
+
+func OpenParquetFiles(ctx context.Context, bkt objstore.Bucket, labelsFileName, chunksFileName string) (*parquet.File, *parquet.File, error) {
+	labelsAttr, err := bkt.Attributes(ctx, labelsFileName)
+	if err != nil {
+		return nil, nil, err
+	}
+	labelsFile, err := parquet.OpenFile(NewBucketReadAt(ctx, labelsFileName, bkt), labelsAttr.Size)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	chunksAttr, err := bkt.Attributes(ctx, chunksFileName)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	chunksFile, err := parquet.OpenFile(NewBucketReadAt(ctx, chunksFileName, bkt), chunksAttr.Size)
+	if err != nil {
+		return nil, nil, err
+	}
+	return labelsFile, chunksFile, nil
+}
+
+// Copied from thanos repository:
+// https://github.com/thanos-io/thanos/blob/2a5a856e34adb2653dda700c4d87637236afb2dd/pkg/store/bucket.go#L3466
+
+type Part struct {
+	Start uint64
+	End   uint64
+
+	ElemRng [2]int
+}
+
+type Partitioner interface {
+	// Partition partitions length entries into n <= length ranges that cover all
+	// input ranges
+	// It supports overlapping ranges.
+	// NOTE: It expects range to be sorted by start time.
+	Partition(length int, rng func(int) (uint64, uint64)) []Part
+}
+
+type gapBasedPartitioner struct {
+	maxGapSize uint64
+}
+
+func NewGapBasedPartitioner(maxGapSize uint64) Partitioner {
+	return gapBasedPartitioner{
+		maxGapSize: maxGapSize,
+	}
+}
+
+// Partition partitions length entries into n <= length ranges that cover all
+// input ranges by combining entries that are separated by reasonably small gaps.
+// It is used to combine multiple small ranges from object storage into bigger, more efficient/cheaper ones.
+func (g gapBasedPartitioner) Partition(length int, rng func(int) (uint64, uint64)) (parts []Part) {
+	j := 0
+	k := 0
+	for k < length {
+		j = k
+		k++
+
+		p := Part{}
+		p.Start, p.End = rng(j)
+
+		// Keep growing the range until the end or we encounter a large gap.
+		for ; k < length; k++ {
+			s, e := rng(k)
+
+			if p.End+g.maxGapSize < s {
+				break
+			}
+
+			if p.End <= e {
+				p.End = e
+			}
+		}
+		p.ElemRng = [2]int{j, k}
+		parts = append(parts, p)
+	}
+	return parts
 }

--- a/util/util.go
+++ b/util/util.go
@@ -1,3 +1,16 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package util
 
 import (

--- a/util/util.go
+++ b/util/util.go
@@ -15,7 +15,7 @@ package util
 
 import (
 	"context"
-	
+
 	"github.com/parquet-go/parquet-go"
 	"github.com/thanos-io/objstore"
 )
@@ -27,15 +27,15 @@ func CloneRows(rows []parquet.Row) []parquet.Row {
 	}
 	return rr
 }
-// OpenParquetFiles opens the labels and chunks files, reading their magic bytes 
-// and footers to validate that the files are properly formatted. 
-// It is the caller's responsibility to close file descriptors when using the files.
-func OpenParquetFiles(ctx context.Context, bkt objstore.Bucket, labelsFileName, chunksFileName string) (*parquet.File, *parquet.File, error) {
+
+// OpenParquetFiles opens the provided labels and chunks Parquet files from the object store,
+// using the options param.
+func OpenParquetFiles(ctx context.Context, bkt objstore.Bucket, labelsFileName, chunksFileName string, options ...parquet.FileOption) (*parquet.File, *parquet.File, error) {
 	labelsAttr, err := bkt.Attributes(ctx, labelsFileName)
 	if err != nil {
 		return nil, nil, err
 	}
-	labelsFile, err := parquet.OpenFile(NewBucketReadAt(ctx, labelsFileName, bkt), labelsAttr.Size)
+	labelsFile, err := parquet.OpenFile(NewBucketReadAt(ctx, labelsFileName, bkt), labelsAttr.Size, options...)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -45,7 +45,7 @@ func OpenParquetFiles(ctx context.Context, bkt objstore.Bucket, labelsFileName, 
 		return nil, nil, err
 	}
 
-	chunksFile, err := parquet.OpenFile(NewBucketReadAt(ctx, chunksFileName, bkt), chunksAttr.Size)
+	chunksFile, err := parquet.OpenFile(NewBucketReadAt(ctx, chunksFileName, bkt), chunksAttr.Size, options...)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/util/util.go
+++ b/util/util.go
@@ -27,7 +27,9 @@ func CloneRows(rows []parquet.Row) []parquet.Row {
 	}
 	return rr
 }
-
+// OpenParquetFiles opens the labels and chunks files, reading their magic bytes 
+// and footers to validate that the files are properly formatted. 
+// It is the caller's responsibility to close file descriptors when using the files.
 func OpenParquetFiles(ctx context.Context, bkt objstore.Bucket, labelsFileName, chunksFileName string) (*parquet.File, *parquet.File, error) {
 	labelsAttr, err := bkt.Attributes(ctx, labelsFileName)
 	if err != nil {

--- a/util/util.go
+++ b/util/util.go
@@ -15,10 +15,15 @@ package util
 
 import (
 	"context"
+	"unsafe"
 
 	"github.com/parquet-go/parquet-go"
 	"github.com/thanos-io/objstore"
 )
+
+func YoloString(buf []byte) string {
+	return *((*string)(unsafe.Pointer(&buf)))
+}
 
 func CloneRows(rows []parquet.Row) []parquet.Row {
 	rr := make([]parquet.Row, len(rows))

--- a/util/util.go
+++ b/util/util.go
@@ -15,15 +15,10 @@ package util
 
 import (
 	"context"
-	"unsafe"
-
+	
 	"github.com/parquet-go/parquet-go"
 	"github.com/thanos-io/objstore"
 )
-
-func YoloString(buf []byte) string {
-	return *((*string)(unsafe.Pointer(&buf)))
-}
 
 func CloneRows(rows []parquet.Row) []parquet.Row {
 	rr := make([]parquet.Row, len(rows))

--- a/util/util.go
+++ b/util/util.go
@@ -1,12 +1,16 @@
 package util
 
 import (
+	"context"
 	"unsafe"
 
-	"context"
 	"github.com/parquet-go/parquet-go"
 	"github.com/thanos-io/objstore"
 )
+
+func YoloString(buf []byte) string {
+	return *((*string)(unsafe.Pointer(&buf)))
+}
 
 func CloneRows(rows []parquet.Row) []parquet.Row {
 	rr := make([]parquet.Row, len(rows))
@@ -14,10 +18,6 @@ func CloneRows(rows []parquet.Row) []parquet.Row {
 		rr[i] = row.Clone()
 	}
 	return rr
-}
-
-func YoloString(buf []byte) string {
-	return *((*string)(unsafe.Pointer(&buf)))
 }
 
 func OpenParquetFiles(ctx context.Context, bkt objstore.Bucket, labelsFileName, chunksFileName string) (*parquet.File, *parquet.File, error) {

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -1,3 +1,16 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package util
 
 import (

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -1,0 +1,80 @@
+package util
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestGapBasedPartitioner(t *testing.T) {
+	tests := []struct {
+		name        string
+		maxGapSize  uint64
+		inputRanges [][2]uint64
+		expected    []Part
+	}{
+		{
+			name:       "no gaps",
+			maxGapSize: 5,
+			inputRanges: [][2]uint64{
+				{0, 10}, {10, 20}, {20, 30},
+			},
+			expected: []Part{
+				{Start: 0, End: 30, ElemRng: [2]int{0, 3}},
+			},
+		},
+		{
+			name:       "small gaps",
+			maxGapSize: 5,
+			inputRanges: [][2]uint64{
+				{0, 10}, {12, 22}, {27, 35},
+			},
+			expected: []Part{
+				{Start: 0, End: 35, ElemRng: [2]int{0, 3}},
+			},
+		},
+		{
+			name:       "large gap splits range",
+			maxGapSize: 3,
+			inputRanges: [][2]uint64{
+				{0, 10}, {20, 30}, {31, 40},
+			},
+			expected: []Part{
+				{Start: 0, End: 10, ElemRng: [2]int{0, 1}},
+				{Start: 20, End: 40, ElemRng: [2]int{1, 3}},
+			},
+		},
+		{
+			name:       "overlapping ranges",
+			maxGapSize: 1,
+			inputRanges: [][2]uint64{
+				{0, 10}, {5, 15}, {14, 20},
+			},
+			expected: []Part{
+				{Start: 0, End: 20, ElemRng: [2]int{0, 3}},
+			},
+		},
+		{
+			name:       "single input",
+			maxGapSize: 100,
+			inputRanges: [][2]uint64{
+				{10, 50},
+			},
+			expected: []Part{
+				{Start: 10, End: 50, ElemRng: [2]int{0, 1}},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := NewGapBasedPartitioner(tt.maxGapSize)
+			result := p.Partition(len(tt.inputRanges), func(i int) (uint64, uint64) {
+				return tt.inputRanges[i][0], tt.inputRanges[i][1]
+			})
+
+			if !reflect.DeepEqual(result, tt.expected) {
+				t.Errorf("unexpected result:\ngot  %#v\nwant %#v", result, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Implement Parquet Materializer

This PR introduces the `Materializer`, a component that reconstructs Prometheus time series from Parquet files containing label metadata and encoded chunks.

#### Usage Example

```
    lf, cf, _ := util.OpenParquetFiles(ctx, bkt, labelsFileName, chunksFileName) // Open labels and chunks files
    s, _ := schema.FromLabelsFile(lf)                                          // Load TSDB schema from the labels file
    d := schema.NewPrometheusParquetChunksDecoder(chunkenc.NewPool())           // Initialize chunk decoder
    m, err := NewMaterializer(s, d, lf, cf)                                      // Create the materializer
    ...
    ...
    rr, err := filter(group, c)                                                 // Filter row groups by constraints
    series, err := m.Materialize(ctx, i, mint, maxt, rr)                        // Materialize series ([]storage.ChunkSeries)
```

Materialize Signature:

```
// Materialize reconstructs the ChunkSeries that belong to the specified row ranges (rr).
// It uses the row group index (rgi) and time bounds (mint, maxt) to filter and decode the series.
func (m *Materializer) Materialize(ctx context.Context, rgi int, mint, maxt int64, rr []rowRange) ([]storage.ChunkSeries, error)
```


PS1: The materialize method will also only read/open the required data columns. 
PS2: Materialize returns `storage.ChunkSeries` which is super convenient.

