### PR TITLE
Removing the SkipByDictionary Opmization

### DIFF
--- a/search/search.go
+++ b/search/search.go
@@ -24,4 +24,5 @@ type Constraint interface {
 	init(s *parquet.Schema) error
 	// path is the path for the column that is constrained
 	path() string
+	String() string
 }


### PR DESCRIPTION
This optimization seems to be cause more harm than good.


This is the new benchmak before/after the removal:

```
goos: darwin
goarch: arm64
pkg: github.com/prometheus-community/parquet-common/search
cpu: Apple M1 Pro
                                                                                                                            │  /tmp/old   │              /tmp/new              │
                                                                                                                            │   sec/op    │   sec/op     vs base               │
Constraints/[equal("A","00000000000000000000")_equal("B","00000000000000000000")_equal("Random","00000000000000000000")]-10   13.21m ± 3%   13.09m ± 4%        ~ (p=0.394 n=6)
Constraints/[equal("A","49949949949949949949")_equal("B","49949949949949949949")_equal("Random","50399503995039950399")]-10   17.62m ± 1%   14.05m ± 4%  -20.25% (p=0.002 n=6)
Constraints/[equal("A","00000000000000000000")_equal("B","00000000000000000000")_regex(Random,00000000000000000000)]-10       13.13m ± 1%   13.05m ± 0%   -0.63% (p=0.004 n=6)
Constraints/[equal("A","49949949949949949949")_equal("B","49949949949949949949")_regex(Random,50399503995039950399)]-10       22.97m ± 2%   14.06m ± 1%  -38.78% (p=0.002 n=6)
geomean                                                                                                                       16.28m        13.55m       -16.73%

                                                                                                                            │   /tmp/old    │              /tmp/new               │
                                                                                                                            │     B/op      │     B/op      vs base               │
Constraints/[equal("A","00000000000000000000")_equal("B","00000000000000000000")_equal("Random","00000000000000000000")]-10    5.856Mi ± 0%   5.863Mi ± 0%        ~ (p=0.818 n=6)
Constraints/[equal("A","49949949949949949949")_equal("B","49949949949949949949")_equal("Random","50399503995039950399")]-10    5.872Mi ± 1%   5.866Mi ± 0%        ~ (p=1.000 n=6)
Constraints/[equal("A","00000000000000000000")_equal("B","00000000000000000000")_regex(Random,00000000000000000000)]-10        5.857Mi ± 0%   5.843Mi ± 1%        ~ (p=0.331 n=6)
Constraints/[equal("A","49949949949949949949")_equal("B","49949949949949949949")_regex(Random,50399503995039950399)]-10       10.899Mi ± 0%   5.875Mi ± 0%  -46.09% (p=0.002 n=6)
geomean                                                                                                                        6.845Mi        5.862Mi       -14.36%

                                                                                                                            │  /tmp/old   │              /tmp/new               │
                                                                                                                            │  allocs/op  │  allocs/op   vs base                │
Constraints/[equal("A","00000000000000000000")_equal("B","00000000000000000000")_equal("Random","00000000000000000000")]-10   5.613k ± 0%   5.613k ± 0%       ~ (p=1.000 n=6) ¹
Constraints/[equal("A","49949949949949949949")_equal("B","49949949949949949949")_equal("Random","50399503995039950399")]-10   5.614k ± 0%   5.614k ± 0%       ~ (p=1.000 n=6)
Constraints/[equal("A","00000000000000000000")_equal("B","00000000000000000000")_regex(Random,00000000000000000000)]-10       5.626k ± 0%   5.626k ± 0%       ~ (p=1.000 n=6) ¹
Constraints/[equal("A","49949949949949949949")_equal("B","49949949949949949949")_regex(Random,50399503995039950399)]-10       5.900k ± 0%   5.626k ± 0%  -4.64% (p=0.002 n=6)
geomean                                                                                                                       5.687k        5.620k       -1.18%
¹ all samples are equal
```


We can see that on the benchmark, if the values being queried is right at the beginning of the dictionary, there is not lots of difference (as we return as soon as we find one value that match).

Its important to note as well that the dictionary is not "per page" but per "column chunks", which means that the same dictionary would be returned on ALL the pages for a given row group.