### PR TITLE
search: fix repeated decoding of same label column index

### DIFF
--- a/search/materialize.go
+++ b/search/materialize.go
@@ -126,16 +126,19 @@ func (m *Materializer) MaterializeLabelNames(ctx context.Context, rgi int, rr []
 		return nil, errors.Wrap(err, "materializer failed to materialize columns")
 	}
 
+	seen := make(map[string]struct{})
 	colsMap := make(map[string]struct{}, 10)
-
 	for _, colsIdx := range colsIdxs {
-		idxs, err := schema.DecodeUintSlice(colsIdx.ByteArray())
-		if err != nil {
-			return nil, errors.Wrap(err, "failed to decode column index")
-		}
-		for _, idx := range idxs {
-			if _, ok := colsMap[m.lf.Schema().Columns()[idx][0]]; !ok {
-				colsMap[m.lf.Schema().Columns()[idx][0]] = struct{}{}
+		key := util.YoloString(colsIdx.ByteArray())
+		if _, ok := seen[key]; !ok {
+			idxs, err := schema.DecodeUintSlice(colsIdx.ByteArray())
+			if err != nil {
+				return nil, errors.Wrap(err, "failed to decode column index")
+			}
+			for _, idx := range idxs {
+				if _, ok := colsMap[m.lf.Schema().Columns()[idx][0]]; !ok {
+					colsMap[m.lf.Schema().Columns()[idx][0]] = struct{}{}
+				}
 			}
 		}
 	}


### PR DESCRIPTION
For "Select" calls with high cardinality result sets we end up deocding the same index over and over again, overwriting the same keys in the colsMap.
Instead we can keep track of which indexes we have seen already and skip repeatedly decoding it.