### PR TITLE
Change the `blocksFinder` to receive the context

### DIFF
--- a/search/parquet_queriable.go
+++ b/search/parquet_queriable.go
@@ -27,16 +27,16 @@ import (
 	"github.com/prometheus-community/parquet-common/util"
 )
 
-type BlocksFinderFunction func(ctx context.Context, mint, maxt int64) ([]*storage.ParquetShard, error)
+type ShardsFinderFunction func(ctx context.Context, mint, maxt int64) ([]*storage.ParquetShard, error)
 
 type parquetQueryable struct {
-	blocksFinder BlocksFinderFunction
+	shardsFinder ShardsFinderFunction
 	d            *schema.PrometheusParquetChunksDecoder
 }
 
-func NewParquetQueryable(d *schema.PrometheusParquetChunksDecoder, blocksFinder BlocksFinderFunction) (prom_storage.Queryable, error) {
+func NewParquetQueryable(d *schema.PrometheusParquetChunksDecoder, blocksFinder ShardsFinderFunction) (prom_storage.Queryable, error) {
 	return &parquetQueryable{
-		blocksFinder: blocksFinder,
+		shardsFinder: blocksFinder,
 		d:            d,
 	}, nil
 }
@@ -45,19 +45,19 @@ func (p parquetQueryable) Querier(mint, maxt int64) (prom_storage.Querier, error
 	return &parquetQuerier{
 		mint:         mint,
 		maxt:         maxt,
-		blocksFinder: p.blocksFinder,
+		shardsFinder: p.shardsFinder,
 		d:            p.d,
 	}, nil
 }
 
 type parquetQuerier struct {
 	mint, maxt   int64
-	blocksFinder BlocksFinderFunction
+	shardsFinder ShardsFinderFunction
 	d            *schema.PrometheusParquetChunksDecoder
 }
 
 func (p parquetQuerier) LabelValues(ctx context.Context, name string, hints *prom_storage.LabelHints, matchers ...*labels.Matcher) ([]string, annotations.Annotations, error) {
-	qBlocks, err := p.queryableBlocks(ctx, p.mint, p.maxt)
+	shards, err := p.queryableShards(ctx, p.mint, p.maxt)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -70,8 +70,8 @@ func (p parquetQuerier) LabelValues(ctx context.Context, name string, hints *pro
 
 	resNameValues := [][]string{}
 
-	for _, b := range qBlocks {
-		r, err := b.LabelValues(ctx, name, matchers)
+	for _, s := range shards {
+		r, err := s.LabelValues(ctx, name, matchers)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -83,7 +83,7 @@ func (p parquetQuerier) LabelValues(ctx context.Context, name string, hints *pro
 }
 
 func (p parquetQuerier) LabelNames(ctx context.Context, hints *prom_storage.LabelHints, matchers ...*labels.Matcher) ([]string, annotations.Annotations, error) {
-	qBlocks, err := p.queryableBlocks(ctx, p.mint, p.maxt)
+	shards, err := p.queryableShards(ctx, p.mint, p.maxt)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -96,8 +96,8 @@ func (p parquetQuerier) LabelNames(ctx context.Context, hints *prom_storage.Labe
 
 	resNameSets := [][]string{}
 
-	for _, b := range qBlocks {
-		r, err := b.LabelNames(ctx, matchers)
+	for _, s := range shards {
+		r, err := s.LabelNames(ctx, matchers)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -113,11 +113,11 @@ func (p parquetQuerier) Close() error {
 }
 
 func (p parquetQuerier) Select(ctx context.Context, sorted bool, sp *prom_storage.SelectHints, matchers ...*labels.Matcher) prom_storage.SeriesSet {
-	qBlocks, err := p.queryableBlocks(ctx, p.mint, p.maxt)
+	shards, err := p.queryableShards(ctx, p.mint, p.maxt)
 	if err != nil {
 		return prom_storage.ErrSeriesSet(err)
 	}
-	seriesSet := make([]prom_storage.ChunkSeriesSet, len(qBlocks))
+	seriesSet := make([]prom_storage.ChunkSeriesSet, len(shards))
 
 	minT, maxT := p.mint, p.maxt
 	if sp != nil {
@@ -125,8 +125,8 @@ func (p parquetQuerier) Select(ctx context.Context, sorted bool, sp *prom_storag
 	}
 	skipChunks := sp != nil && sp.Func == "series"
 
-	for i, block := range qBlocks {
-		ss, err := block.Query(ctx, sorted, minT, maxT, skipChunks, matchers)
+	for i, shard := range shards {
+		ss, err := shard.Query(ctx, sorted, minT, maxT, skipChunks, matchers)
 		if err != nil {
 			return prom_storage.ErrSeriesSet(err)
 		}
@@ -137,14 +137,14 @@ func (p parquetQuerier) Select(ctx context.Context, sorted bool, sp *prom_storag
 	return convert.NewSeriesSetFromChunkSeriesSet(ss, skipChunks)
 }
 
-func (p parquetQuerier) queryableBlocks(ctx context.Context, mint, maxt int64) ([]*queryableBlock, error) {
-	blocks, err := p.blocksFinder(ctx, mint, maxt)
+func (p parquetQuerier) queryableShards(ctx context.Context, mint, maxt int64) ([]*queryableShard, error) {
+	shards, err := p.shardsFinder(ctx, mint, maxt)
 	if err != nil {
 		return nil, err
 	}
-	qBlocks := make([]*queryableBlock, len(blocks))
-	for i, b := range blocks {
-		qb, err := newQueryableBlock(b, p.d)
+	qBlocks := make([]*queryableShard, len(shards))
+	for i, shard := range shards {
+		qb, err := newQueryableShard(shard, p.d)
 		if err != nil {
 			return nil, err
 		}
@@ -153,12 +153,12 @@ func (p parquetQuerier) queryableBlocks(ctx context.Context, mint, maxt int64) (
 	return qBlocks, nil
 }
 
-type queryableBlock struct {
-	block *storage.ParquetShard
+type queryableShard struct {
+	shard *storage.ParquetShard
 	m     *Materializer
 }
 
-func newQueryableBlock(block *storage.ParquetShard, d *schema.PrometheusParquetChunksDecoder) (*queryableBlock, error) {
+func newQueryableShard(block *storage.ParquetShard, d *schema.PrometheusParquetChunksDecoder) (*queryableShard, error) {
 	s, err := block.TSDBSchema()
 	if err != nil {
 		return nil, err
@@ -168,24 +168,24 @@ func newQueryableBlock(block *storage.ParquetShard, d *schema.PrometheusParquetC
 		return nil, err
 	}
 
-	return &queryableBlock{
-		block: block,
+	return &queryableShard{
+		shard: block,
 		m:     m,
 	}, nil
 }
 
-func (b queryableBlock) Query(ctx context.Context, sorted bool, mint, maxt int64, skipChunks bool, matchers []*labels.Matcher) (prom_storage.ChunkSeriesSet, error) {
+func (b queryableShard) Query(ctx context.Context, sorted bool, mint, maxt int64, skipChunks bool, matchers []*labels.Matcher) (prom_storage.ChunkSeriesSet, error) {
 	cs, err := MatchersToConstraint(matchers...)
 	if err != nil {
 		return nil, err
 	}
-	err = Initialize(b.block.LabelsFile(), cs...)
+	err = Initialize(b.shard.LabelsFile(), cs...)
 	if err != nil {
 		return nil, err
 	}
 
 	results := make([]prom_storage.ChunkSeries, 0, 1024)
-	for i, group := range b.block.LabelsFile().RowGroups() {
+	for i, group := range b.shard.LabelsFile().RowGroups() {
 		rr, err := Filter(ctx, group, cs...)
 		if err != nil {
 			return nil, err
@@ -203,7 +203,7 @@ func (b queryableBlock) Query(ctx context.Context, sorted bool, mint, maxt int64
 	return convert.NewChunksSeriesSet(results), nil
 }
 
-func (b queryableBlock) LabelNames(ctx context.Context, matchers []*labels.Matcher) ([][]string, error) {
+func (b queryableShard) LabelNames(ctx context.Context, matchers []*labels.Matcher) ([][]string, error) {
 	if len(matchers) == 0 {
 		return [][]string{b.m.MaterializeAllLabelNames()}, nil
 	}
@@ -211,13 +211,13 @@ func (b queryableBlock) LabelNames(ctx context.Context, matchers []*labels.Match
 	if err != nil {
 		return nil, err
 	}
-	err = Initialize(b.block.LabelsFile(), cs...)
+	err = Initialize(b.shard.LabelsFile(), cs...)
 	if err != nil {
 		return nil, err
 	}
 
-	results := make([][]string, len(b.block.LabelsFile().RowGroups()))
-	for i, group := range b.block.LabelsFile().RowGroups() {
+	results := make([][]string, len(b.shard.LabelsFile().RowGroups()))
+	for i, group := range b.shard.LabelsFile().RowGroups() {
 		rr, err := Filter(ctx, group, cs...)
 		if err != nil {
 			return nil, err
@@ -232,7 +232,7 @@ func (b queryableBlock) LabelNames(ctx context.Context, matchers []*labels.Match
 	return results, nil
 }
 
-func (b queryableBlock) LabelValues(ctx context.Context, name string, matchers []*labels.Matcher) ([][]string, error) {
+func (b queryableShard) LabelValues(ctx context.Context, name string, matchers []*labels.Matcher) ([][]string, error) {
 	if len(matchers) == 0 {
 		return b.allLabelValues(ctx, name)
 	}
@@ -240,13 +240,13 @@ func (b queryableBlock) LabelValues(ctx context.Context, name string, matchers [
 	if err != nil {
 		return nil, err
 	}
-	err = Initialize(b.block.LabelsFile(), cs...)
+	err = Initialize(b.shard.LabelsFile(), cs...)
 	if err != nil {
 		return nil, err
 	}
 
-	results := make([][]string, len(b.block.LabelsFile().RowGroups()))
-	for i, group := range b.block.LabelsFile().RowGroups() {
+	results := make([][]string, len(b.shard.LabelsFile().RowGroups()))
+	for i, group := range b.shard.LabelsFile().RowGroups() {
 		rr, err := Filter(ctx, group, cs...)
 		if err != nil {
 			return nil, err
@@ -261,9 +261,9 @@ func (b queryableBlock) LabelValues(ctx context.Context, name string, matchers [
 	return results, nil
 }
 
-func (b queryableBlock) allLabelValues(ctx context.Context, name string) ([][]string, error) {
-	results := make([][]string, len(b.block.LabelsFile().RowGroups()))
-	for i := range b.block.LabelsFile().RowGroups() {
+func (b queryableShard) allLabelValues(ctx context.Context, name string) ([][]string, error) {
+	results := make([][]string, len(b.shard.LabelsFile().RowGroups()))
+	for i := range b.shard.LabelsFile().RowGroups() {
 		series, err := b.m.MaterializeAllLabelValues(ctx, name, i)
 		if err != nil {
 			return nil, err

--- a/search/parquet_queriable.go
+++ b/search/parquet_queriable.go
@@ -34,9 +34,9 @@ type parquetQueryable struct {
 	d            *schema.PrometheusParquetChunksDecoder
 }
 
-func NewParquetQueryable(d *schema.PrometheusParquetChunksDecoder, blocksFinder ShardsFinderFunction) (prom_storage.Queryable, error) {
+func NewParquetQueryable(d *schema.PrometheusParquetChunksDecoder, shardFinder ShardsFinderFunction) (prom_storage.Queryable, error) {
 	return &parquetQueryable{
-		shardsFinder: blocksFinder,
+		shardsFinder: shardFinder,
 		d:            d,
 	}, nil
 }

--- a/search/parquet_queriable_test.go
+++ b/search/parquet_queriable_test.go
@@ -287,7 +287,7 @@ func queryWithQueryable(t *testing.T, mint, maxt int64, shard *storage.ParquetSh
 
 func createQueryable(shard *storage.ParquetShard) (prom_storage.Queryable, error) {
 	d := schema.NewPrometheusParquetChunksDecoder(chunkenc.NewPool())
-	return NewParquetQueryable(d, func(mint, maxt int64) []*storage.ParquetShard {
-		return []*storage.ParquetShard{shard}
+	return NewParquetQueryable(d, func(ctx context.Context, mint, maxt int64) ([]*storage.ParquetShard, error) {
+		return []*storage.ParquetShard{shard}, nil
 	})
 }


### PR DESCRIPTION
This allow to cancel the "block search" if the context get cancelled.


The PR also rename the function from `blocksFinder` to `shardsFinder` to be consistent with the `storage.ParquetShard` naming.

Usage:

```
pq, err := search.NewParquetQueryable(nil, func(ctx context.Context, mint, maxt int64) ([]*parquet_storage.ParquetShard, error) {
	blocks := []string{} // Somehow get the blocks to be queried 

	shards := make([]*storage.ParquetShard, 0, len(blocks))
	for _, bId := range blocks {
		// opening shard 0 of each block
		shard, err := parquet_storage.OpenParquetShard(ctx, bkt, bId, 0)
		if err != nil {
			return nil, err
		}
		shards = append(shards, shard)
	}
	return shards, nil
})
```

