### PR TITLE
Opmize Map Access on the prometheus encoding

### DIFF
--- a/schema/encoder.go
+++ b/schema/encoder.go
@@ -95,11 +95,12 @@ func (e *PrometheusParquetChunksEncoder) Encode(it chunks.Iterator) ([][]byte, e
 
 				chkIdx := e.schema.DataColumIdx(t)
 				reEncodedChunksAppenders[chkIdx][chunkenc.EncXOR].Append(t, v)
-				if t < reEncodedChunks[chkIdx][chunkenc.EncXOR][len(reEncodedChunks[chkIdx][chunkenc.EncXOR])-1].MinTime {
-					reEncodedChunks[chkIdx][chunkenc.EncXOR][len(reEncodedChunks[chkIdx][chunkenc.EncXOR])-1].MinTime = t
+				chunk := reEncodedChunks[chkIdx][chunkenc.EncXOR][len(reEncodedChunks[chkIdx][chunkenc.EncXOR])-1]
+				if t < chunk.MinTime {
+					chunk.MinTime = t
 				}
-				if t > reEncodedChunks[chkIdx][chunkenc.EncXOR][len(reEncodedChunks[chkIdx][chunkenc.EncXOR])-1].MaxTime {
-					reEncodedChunks[chkIdx][chunkenc.EncXOR][len(reEncodedChunks[chkIdx][chunkenc.EncXOR])-1].MaxTime = t
+				if t > chunk.MaxTime {
+					chunk.MaxTime = t
 				}
 			}
 		case chunkenc.EncFloatHistogram:
@@ -124,11 +125,12 @@ func (e *PrometheusParquetChunksEncoder) Encode(it chunks.Iterator) ([][]byte, e
 					reEncodedChunks[chkIdx][chunkenc.EncFloatHistogram][len(reEncodedChunks[chkIdx][chunkenc.EncFloatHistogram])-1].Chunk = newC
 				}
 
-				if t < reEncodedChunks[chkIdx][chunkenc.EncFloatHistogram][len(reEncodedChunks[chkIdx][chunkenc.EncFloatHistogram])-1].MinTime {
-					reEncodedChunks[chkIdx][chunkenc.EncFloatHistogram][len(reEncodedChunks[chkIdx][chunkenc.EncFloatHistogram])-1].MinTime = t
+				chunk := reEncodedChunks[chkIdx][chunkenc.EncFloatHistogram][len(reEncodedChunks[chkIdx][chunkenc.EncFloatHistogram])-1]
+				if t < chunk.MinTime {
+					chunk.MinTime = t
 				}
-				if t > reEncodedChunks[chkIdx][chunkenc.EncFloatHistogram][len(reEncodedChunks[chkIdx][chunkenc.EncFloatHistogram])-1].MaxTime {
-					reEncodedChunks[chkIdx][chunkenc.EncFloatHistogram][len(reEncodedChunks[chkIdx][chunkenc.EncFloatHistogram])-1].MaxTime = t
+				if t > chunk.MaxTime {
+					chunk.MaxTime = t
 				}
 			}
 		case chunkenc.EncHistogram:
@@ -153,11 +155,12 @@ func (e *PrometheusParquetChunksEncoder) Encode(it chunks.Iterator) ([][]byte, e
 					reEncodedChunks[chkIdx][chunkenc.EncHistogram][len(reEncodedChunks[chkIdx][chunkenc.EncHistogram])-1].Chunk = newC
 				}
 
-				if t < reEncodedChunks[chkIdx][chunkenc.EncHistogram][len(reEncodedChunks[chkIdx][chunkenc.EncHistogram])-1].MinTime {
-					reEncodedChunks[chkIdx][chunkenc.EncHistogram][len(reEncodedChunks[chkIdx][chunkenc.EncHistogram])-1].MinTime = t
+				chunk := reEncodedChunks[chkIdx][chunkenc.EncHistogram][len(reEncodedChunks[chkIdx][chunkenc.EncHistogram])-1]
+				if t < chunk.MinTime {
+					chunk.MinTime = t
 				}
-				if t > reEncodedChunks[chkIdx][chunkenc.EncHistogram][len(reEncodedChunks[chkIdx][chunkenc.EncHistogram])-1].MaxTime {
-					reEncodedChunks[chkIdx][chunkenc.EncHistogram][len(reEncodedChunks[chkIdx][chunkenc.EncHistogram])-1].MaxTime = t
+				if t > chunk.MaxTime {
+					chunk.MaxTime = t
 				}
 			}
 		default:


### PR DESCRIPTION
We are spending lots of CPU accessing the map during chunks encoding.

This is a small change to reduce the number of map access on that code path.
![Screenshot 2025-05-26 at 2 06 15 PM](https://github.com/user-attachments/assets/ad0c4c5d-1eb6-43ae-a5d1-44cf56998b90)

