### PR TITLE
Implementing max samples per chunk on parquet (WIP)

### DIFF
--- a/schema/encoder.go
+++ b/schema/encoder.go
@@ -60,26 +60,11 @@ func (e *PrometheusParquetChunksEncoder) Encode(it chunks.Iterator) ([][]byte, e
 		reEncodedChunksAppenders[i] = make(map[chunkenc.Encoding]chunkenc.Appender)
 
 		for _, enc := range []chunkenc.Encoding{chunkenc.EncXOR, chunkenc.EncHistogram, chunkenc.EncFloatHistogram} {
-			var chunk chunkenc.Chunk
-			switch enc {
-			case chunkenc.EncXOR:
-				chunk = chunkenc.NewXORChunk()
-			case chunkenc.EncHistogram:
-				chunk = chunkenc.NewHistogramChunk()
-			case chunkenc.EncFloatHistogram:
-				chunk = chunkenc.NewFloatHistogramChunk()
-			default:
-				return nil, fmt.Errorf("unknown encoding %v", enc)
-			}
-
-			reEncodedChunks[i][enc] = append(reEncodedChunks[i][enc], &chunks.Meta{
-				Chunk:   chunk,
-				MinTime: math.MaxInt64,
-			})
-			app, err := reEncodedChunks[i][enc][0].Chunk.Appender()
+			nChunk, app, err := e.cutNewChunk(enc)
 			if err != nil {
 				return nil, err
 			}
+			reEncodedChunks[i][enc] = append(reEncodedChunks[i][enc], nChunk)
 			reEncodedChunksAppenders[i][enc] = app
 		}
 	}
@@ -105,16 +90,12 @@ func (e *PrometheusParquetChunksEncoder) Encode(it chunks.Iterator) ([][]byte, e
 					chunk.MaxTime = t
 				}
 				if chunk.Chunk.NumSamples() >= e.samplesPerChunk {
-					nChunk := &chunks.Meta{
-						Chunk:   chunkenc.NewXORChunk(),
-						MinTime: math.MaxInt64,
-					}
-					reEncodedChunks[chkIdx][chunkenc.EncXOR] = append(reEncodedChunks[chkIdx][chunkenc.EncXOR], nChunk)
-
-					app, err := nChunk.Chunk.Appender()
+					nChunk, app, err := e.cutNewChunk(chunkenc.EncXOR)
 					if err != nil {
 						return nil, err
 					}
+
+					reEncodedChunks[chkIdx][chunkenc.EncXOR] = append(reEncodedChunks[chkIdx][chunkenc.EncXOR], nChunk)
 					reEncodedChunksAppenders[chkIdx][chunkenc.EncXOR] = app
 				}
 			}
@@ -147,6 +128,16 @@ func (e *PrometheusParquetChunksEncoder) Encode(it chunks.Iterator) ([][]byte, e
 				if t > chunk.MaxTime {
 					chunk.MaxTime = t
 				}
+
+				if chunk.Chunk.NumSamples() >= e.samplesPerChunk {
+					nChunk, app, err := e.cutNewChunk(chunkenc.EncFloatHistogram)
+					if err != nil {
+						return nil, err
+					}
+
+					reEncodedChunks[chkIdx][chunkenc.EncFloatHistogram] = append(reEncodedChunks[chkIdx][chunkenc.EncFloatHistogram], nChunk)
+					reEncodedChunksAppenders[chkIdx][chunkenc.EncFloatHistogram] = app
+				}
 			}
 		case chunkenc.EncHistogram:
 			for vt := sampleIt.Next(); vt != chunkenc.ValNone; vt = sampleIt.Next() {
@@ -177,6 +168,16 @@ func (e *PrometheusParquetChunksEncoder) Encode(it chunks.Iterator) ([][]byte, e
 				if t > chunk.MaxTime {
 					chunk.MaxTime = t
 				}
+
+				if chunk.Chunk.NumSamples() >= e.samplesPerChunk {
+					nChunk, app, err := e.cutNewChunk(chunkenc.EncHistogram)
+					if err != nil {
+						return nil, err
+					}
+
+					reEncodedChunks[chkIdx][chunkenc.EncHistogram] = append(reEncodedChunks[chkIdx][chunkenc.EncHistogram], nChunk)
+					reEncodedChunksAppenders[chkIdx][chunkenc.EncHistogram] = app
+				}
 			}
 		default:
 			return nil, fmt.Errorf("unknown encoding %v", chk.Chunk.Encoding())
@@ -205,6 +206,29 @@ func (e *PrometheusParquetChunksEncoder) Encode(it chunks.Iterator) ([][]byte, e
 		}
 	}
 	return result, nil
+}
+
+func (e *PrometheusParquetChunksEncoder) cutNewChunk(enc chunkenc.Encoding) (*chunks.Meta, chunkenc.Appender, error) {
+	var chunk chunkenc.Chunk
+
+	switch enc {
+	case chunkenc.EncXOR:
+		chunk = chunkenc.NewXORChunk()
+	case chunkenc.EncHistogram:
+		chunk = chunkenc.NewHistogramChunk()
+	case chunkenc.EncFloatHistogram:
+		chunk = chunkenc.NewFloatHistogramChunk()
+	default:
+		return nil, nil, fmt.Errorf("unknown encoding %v", enc)
+	}
+
+	nChunk := &chunks.Meta{
+		Chunk:   chunk,
+		MinTime: math.MaxInt64,
+	}
+
+	app, err := nChunk.Chunk.Appender()
+	return nChunk, app, err
 }
 
 type PrometheusParquetChunksDecoder struct {

--- a/schema/encoder_test.go
+++ b/schema/encoder_test.go
@@ -32,7 +32,7 @@ import (
 func TestEncodeDecode(t *testing.T) {
 	ts := promqltest.LoadedStorage(t, `
 load 1m
-	float_only{env="prod"} 5 2+3x20
+	float_only{env="prod"} 5 2+3x200
     float_histogram_conversion{env="prod"} 5 2+3x2 _ stale {{schema:1 sum:3 count:22 buckets:[5 10 7]}}
 	http_requests_histogram{job="api-server", instance="3", group="canary"} {{schema:2 count:4 sum:10 buckets:[1 0 0 0 1 0 0 1 1]}}
     histogram_with_reset_bucket{le="1"} 1  3  9
@@ -57,7 +57,8 @@ load_with_nhcb 1m
 	mint, maxt := ts.Head().MinTime(), ts.Head().MaxTime()
 	sb := NewBuilder(mint, maxt, (time.Minute * 60).Milliseconds())
 	s, err := sb.Build()
-	enc := NewPrometheusParquetChunksEncoder(s)
+	maxSamplesPerChunk := 30
+	enc := NewPrometheusParquetChunksEncoder(s, maxSamplesPerChunk)
 	dec := NewPrometheusParquetChunksDecoder(chunkenc.NewPool())
 
 	require.NoError(t, err)
@@ -87,8 +88,8 @@ load_with_nhcb 1m
 		for _, chunksByTime := range decodedChunksByTime {
 			decodedChunkMeta, err := dec.Decode(chunksByTime, mint, maxt)
 			require.NoError(t, err)
-			require.Len(t, decodedChunkMeta, len(chks))
 			for _, decodedChunk := range decodedChunkMeta {
+				require.LessOrEqual(t, decodedChunk.Chunk.NumSamples(), maxSamplesPerChunk)
 				decodedSamples += decodedChunk.Chunk.NumSamples()
 			}
 		}

--- a/schema/encoder_test.go
+++ b/schema/encoder_test.go
@@ -33,8 +33,8 @@ func TestEncodeDecode(t *testing.T) {
 	ts := promqltest.LoadedStorage(t, `
 load 1m
 	float_only{env="prod"} 5 2+3x200
-    float_histogram_conversion{env="prod"} 5 2+3x2 _ stale {{schema:1 sum:3 count:22 buckets:[5 10 7]}}
-	http_requests_histogram{job="api-server", instance="3", group="canary"} {{schema:2 count:4 sum:10 buckets:[1 0 0 0 1 0 0 1 1]}}
+    float_histogram_conversion{env="prod"} 5 2+3x2 _ stale {{schema:1 sum:3 count:22 buckets:[5 10 7]}}x200
+	http_requests_histogram{job="api-server", instance="3", group="canary"} {{schema:2 count:4 sum:10 buckets:[1 0 0 0 1 0 0 1 1]}}x200
     histogram_with_reset_bucket{le="1"} 1  3  9
     histogram_with_reset_bucket{le="2"} 3  3  9
     histogram_with_reset_bucket{le="4"} 8  5 12


### PR DESCRIPTION
This PR introduces a new configuration option to set the maximum number of samples per chunk.

This option is particularly useful to avoid decoding large chunks when querying only a small time range within a day. For example, in Cortex, we typically split queries by "day," which means that even when querying just the last 5 minutes of the previous day, we might end up decoding an entire 8-hour chunk. This results in unnecessary CPU cycles spent processing irrelevant data.

By allowing smaller chunk sizes, we can significantly reduce the overhead of decoding, improving efficiency and performance during partial time range queries.

![image](https://github.com/user-attachments/assets/da4a0d55-5405-444a-ad05-08cf81c57c1b)
