### PR TITLE
feat: support write & read Parquet files from local disk

### DIFF
--- a/convert/convert.go
+++ b/convert/convert.go
@@ -187,7 +187,9 @@ func ConvertTSDBBlock(
 		labelsProjection, chunksProjection,
 	}
 
-	w := NewShardedWrite(rr, rr.Schema(), outSchemaProjections, bkt, &cfg)
+	writeFunc := PipeReaderBucketWriteFunc(bkt)
+
+	w := NewShardedWrite(rr, rr.Schema(), outSchemaProjections, writeFunc, &cfg)
 	return w.currentShard, errors.Wrap(w.Write(ctx), "error writing block")
 }
 

--- a/convert/convert.go
+++ b/convert/convert.go
@@ -187,9 +187,8 @@ func ConvertTSDBBlock(
 		labelsProjection, chunksProjection,
 	}
 
-	writeFunc := PipeReaderBucketWriteFunc(bkt)
-
-	w := NewShardedWrite(rr, rr.Schema(), outSchemaProjections, writeFunc, &cfg)
+	pipeReaderWriter := NewPipeReaderBucketWriter(bkt)
+	w := NewShardedWrite(rr, rr.Schema(), outSchemaProjections, pipeReaderWriter, &cfg)
 	return w.currentShard, errors.Wrap(w.Write(ctx), "error writing block")
 }
 

--- a/convert/convert.go
+++ b/convert/convert.go
@@ -71,10 +71,6 @@ type convertOpts struct {
 	maxSamplesPerChunk int
 }
 
-func (cfg convertOpts) Name() string {
-	return cfg.name
-}
-
 func (cfg convertOpts) buildBloomfilterColumns() []parquet.BloomFilterColumn {
 	cols := make([]parquet.BloomFilterColumn, 0, len(cfg.bloomfilterLabels))
 	for _, label := range cfg.bloomfilterLabels {

--- a/convert/convert.go
+++ b/convert/convert.go
@@ -71,6 +71,10 @@ type convertOpts struct {
 	maxSamplesPerChunk int
 }
 
+func (cfg convertOpts) Name() string {
+	return cfg.name
+}
+
 func (cfg convertOpts) buildBloomfilterColumns() []parquet.BloomFilterColumn {
 	cols := make([]parquet.BloomFilterColumn, 0, len(cfg.bloomfilterLabels))
 	for _, label := range cfg.bloomfilterLabels {

--- a/convert/convert_test.go
+++ b/convert/convert_test.go
@@ -102,8 +102,12 @@ func Test_Convert_TSDB(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, 1, shards)
 
-			shard, err := storage.OpenParquetShardFromBucket(ctx, bkt, DefaultConvertOpts.Name(), 0)
+			bucketOpener := storage.NewParquetBucketOpener(bkt)
+			shard, err := storage.NewParquetShardSyncOpener(
+				ctx, DefaultConvertOpts.Name(), bucketOpener, bucketOpener, 0,
+			)
 			require.NoError(t, err)
+
 			require.Equal(t, len(shard.LabelsFile().RowGroups()), len(shard.ChunksFile().RowGroups()))
 			series, chunks, err := readSeries(t, shard)
 			require.NoError(t, err)
@@ -179,7 +183,10 @@ func Test_CreateParquetWithReducedTimestampSamples(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 1, shards)
 
-	shard, err := storage.OpenParquetShardFromBucket(ctx, bkt, DefaultConvertOpts.Name(), 0)
+	bucketOpener := storage.NewParquetBucketOpener(bkt)
+	shard, err := storage.NewParquetShardSyncOpener(
+		ctx, DefaultConvertOpts.Name(), bucketOpener, bucketOpener, 0,
+	)
 	require.NoError(t, err)
 
 	// Check metadatas
@@ -266,7 +273,10 @@ func Test_BlockHasOnlySomeSeriesInConvertTime(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 1, shards)
 
-	shard, err := storage.OpenParquetShardFromBucket(ctx, bkt, DefaultConvertOpts.Name(), 0)
+	bucketOpener := storage.NewParquetBucketOpener(bkt)
+	shard, err := storage.NewParquetShardSyncOpener(
+		ctx, DefaultConvertOpts.Name(), bucketOpener, bucketOpener, 0,
+	)
 	require.NoError(t, err)
 
 	series, _, err := readSeries(t, shard)
@@ -341,7 +351,10 @@ func Test_SortedLabels(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 1, shards)
 
-	shard, err := storage.OpenParquetShardFromBucket(ctx, bkt, DefaultConvertOpts.Name(), 0)
+	bucketOpener := storage.NewParquetBucketOpener(bkt)
+	shard, err := storage.NewParquetShardSyncOpener(
+		ctx, DefaultConvertOpts.Name(), bucketOpener, bucketOpener, 0,
+	)
 	require.NoError(t, err)
 
 	series, chunks, err := readSeries(t, shard)

--- a/convert/convert_test.go
+++ b/convert/convert_test.go
@@ -102,7 +102,7 @@ func Test_Convert_TSDB(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, 1, shards)
 
-			shard, err := storage.OpenParquetShard(ctx, bkt, DefaultConvertOpts.name, 0)
+			shard, err := storage.OpenParquetShardFromBucket(ctx, bkt, DefaultConvertOpts.name, 0)
 			require.NoError(t, err)
 			require.Equal(t, len(shard.LabelsFile().RowGroups()), len(shard.ChunksFile().RowGroups()))
 			series, chunks, err := readSeries(t, shard)
@@ -179,7 +179,7 @@ func Test_CreateParquetWithReducedTimestampSamples(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 1, shards)
 
-	shard, err := storage.OpenParquetShard(ctx, bkt, DefaultConvertOpts.name, 0)
+	shard, err := storage.OpenParquetShardFromBucket(ctx, bkt, DefaultConvertOpts.name, 0)
 	require.NoError(t, err)
 
 	// Check metadatas
@@ -266,7 +266,7 @@ func Test_BlockHasOnlySomeSeriesInConvertTime(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 1, shards)
 
-	shard, err := storage.OpenParquetShard(ctx, bkt, DefaultConvertOpts.name, 0)
+	shard, err := storage.OpenParquetShardFromBucket(ctx, bkt, DefaultConvertOpts.name, 0)
 	require.NoError(t, err)
 
 	series, _, err := readSeries(t, shard)
@@ -341,7 +341,7 @@ func Test_SortedLabels(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 1, shards)
 
-	shard, err := storage.OpenParquetShard(ctx, bkt, DefaultConvertOpts.name, 0)
+	shard, err := storage.OpenParquetShardFromBucket(ctx, bkt, DefaultConvertOpts.name, 0)
 	require.NoError(t, err)
 
 	series, chunks, err := readSeries(t, shard)

--- a/convert/convert_test.go
+++ b/convert/convert_test.go
@@ -102,7 +102,7 @@ func Test_Convert_TSDB(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, 1, shards)
 
-			shard, err := storage.OpenParquetShardFromBucket(ctx, bkt, DefaultConvertOpts.name, 0)
+			shard, err := storage.OpenParquetShardFromBucket(ctx, bkt, DefaultConvertOpts.Name(), 0)
 			require.NoError(t, err)
 			require.Equal(t, len(shard.LabelsFile().RowGroups()), len(shard.ChunksFile().RowGroups()))
 			series, chunks, err := readSeries(t, shard)
@@ -179,7 +179,7 @@ func Test_CreateParquetWithReducedTimestampSamples(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 1, shards)
 
-	shard, err := storage.OpenParquetShardFromBucket(ctx, bkt, DefaultConvertOpts.name, 0)
+	shard, err := storage.OpenParquetShardFromBucket(ctx, bkt, DefaultConvertOpts.Name(), 0)
 	require.NoError(t, err)
 
 	// Check metadatas
@@ -266,7 +266,7 @@ func Test_BlockHasOnlySomeSeriesInConvertTime(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 1, shards)
 
-	shard, err := storage.OpenParquetShardFromBucket(ctx, bkt, DefaultConvertOpts.name, 0)
+	shard, err := storage.OpenParquetShardFromBucket(ctx, bkt, DefaultConvertOpts.Name(), 0)
 	require.NoError(t, err)
 
 	series, _, err := readSeries(t, shard)
@@ -341,7 +341,7 @@ func Test_SortedLabels(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 1, shards)
 
-	shard, err := storage.OpenParquetShardFromBucket(ctx, bkt, DefaultConvertOpts.name, 0)
+	shard, err := storage.OpenParquetShardFromBucket(ctx, bkt, DefaultConvertOpts.Name(), 0)
 	require.NoError(t, err)
 
 	series, chunks, err := readSeries(t, shard)

--- a/convert/convert_test.go
+++ b/convert/convert_test.go
@@ -104,7 +104,7 @@ func Test_Convert_TSDB(t *testing.T) {
 
 			bucketOpener := storage.NewParquetBucketOpener(bkt)
 			shard, err := storage.NewParquetShardSyncOpener(
-				ctx, DefaultConvertOpts.Name(), bucketOpener, bucketOpener, 0,
+				ctx, DefaultConvertOpts.name, bucketOpener, bucketOpener, 0,
 			)
 			require.NoError(t, err)
 
@@ -185,7 +185,7 @@ func Test_CreateParquetWithReducedTimestampSamples(t *testing.T) {
 
 	bucketOpener := storage.NewParquetBucketOpener(bkt)
 	shard, err := storage.NewParquetShardSyncOpener(
-		ctx, DefaultConvertOpts.Name(), bucketOpener, bucketOpener, 0,
+		ctx, DefaultConvertOpts.name, bucketOpener, bucketOpener, 0,
 	)
 	require.NoError(t, err)
 
@@ -275,7 +275,7 @@ func Test_BlockHasOnlySomeSeriesInConvertTime(t *testing.T) {
 
 	bucketOpener := storage.NewParquetBucketOpener(bkt)
 	shard, err := storage.NewParquetShardSyncOpener(
-		ctx, DefaultConvertOpts.Name(), bucketOpener, bucketOpener, 0,
+		ctx, DefaultConvertOpts.name, bucketOpener, bucketOpener, 0,
 	)
 	require.NoError(t, err)
 
@@ -353,7 +353,7 @@ func Test_SortedLabels(t *testing.T) {
 
 	bucketOpener := storage.NewParquetBucketOpener(bkt)
 	shard, err := storage.NewParquetShardSyncOpener(
-		ctx, DefaultConvertOpts.Name(), bucketOpener, bucketOpener, 0,
+		ctx, DefaultConvertOpts.name, bucketOpener, bucketOpener, 0,
 	)
 	require.NoError(t, err)
 

--- a/convert/convert_test.go
+++ b/convert/convert_test.go
@@ -371,7 +371,7 @@ func Test_SortedLabels(t *testing.T) {
 	}
 }
 
-func readSeries(t *testing.T, shard *storage.ParquetShard) ([]labels.Labels, [][]chunks.Meta, error) {
+func readSeries(t *testing.T, shard storage.ParquetShard) ([]labels.Labels, [][]chunks.Meta, error) {
 	lr := parquet.NewGenericReader[any](shard.LabelsFile().File)
 	cr := parquet.NewGenericReader[any](shard.ChunksFile().File)
 

--- a/convert/convert_test.go
+++ b/convert/convert_test.go
@@ -103,7 +103,7 @@ func Test_Convert_TSDB(t *testing.T) {
 			require.Equal(t, 1, shards)
 
 			bucketOpener := storage.NewParquetBucketOpener(bkt)
-			shard, err := storage.NewParquetShardSyncOpener(
+			shard, err := storage.NewParquetShardOpener(
 				ctx, DefaultConvertOpts.name, bucketOpener, bucketOpener, 0,
 			)
 			require.NoError(t, err)
@@ -184,7 +184,7 @@ func Test_CreateParquetWithReducedTimestampSamples(t *testing.T) {
 	require.Equal(t, 1, shards)
 
 	bucketOpener := storage.NewParquetBucketOpener(bkt)
-	shard, err := storage.NewParquetShardSyncOpener(
+	shard, err := storage.NewParquetShardOpener(
 		ctx, DefaultConvertOpts.name, bucketOpener, bucketOpener, 0,
 	)
 	require.NoError(t, err)
@@ -274,7 +274,7 @@ func Test_BlockHasOnlySomeSeriesInConvertTime(t *testing.T) {
 	require.Equal(t, 1, shards)
 
 	bucketOpener := storage.NewParquetBucketOpener(bkt)
-	shard, err := storage.NewParquetShardSyncOpener(
+	shard, err := storage.NewParquetShardOpener(
 		ctx, DefaultConvertOpts.name, bucketOpener, bucketOpener, 0,
 	)
 	require.NoError(t, err)
@@ -352,7 +352,7 @@ func Test_SortedLabels(t *testing.T) {
 	require.Equal(t, 1, shards)
 
 	bucketOpener := storage.NewParquetBucketOpener(bkt)
-	shard, err := storage.NewParquetShardSyncOpener(
+	shard, err := storage.NewParquetShardOpener(
 		ctx, DefaultConvertOpts.name, bucketOpener, bucketOpener, 0,
 	)
 	require.NoError(t, err)

--- a/convert/merge.go
+++ b/convert/merge.go
@@ -16,10 +16,9 @@ package convert
 import (
 	"container/heap"
 
-	"github.com/prometheus/prometheus/tsdb/chunkenc"
-
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/storage"
+	"github.com/prometheus/prometheus/tsdb/chunkenc"
 	"github.com/prometheus/prometheus/util/annotations"
 )
 

--- a/convert/writer.go
+++ b/convert/writer.go
@@ -52,7 +52,6 @@ func NewShardedWrite(
 	bkt objstore.Bucket,
 	ops *convertOpts,
 ) *ShardedWriter {
-
 	return &ShardedWriter{
 		name:                 ops.name,
 		rowGroupSize:         ops.rowGroupSize,

--- a/convert/writer.go
+++ b/convert/writer.go
@@ -53,7 +53,7 @@ func NewShardedWrite(
 	ops *convertOpts,
 ) *ShardedWriter {
 	return &ShardedWriter{
-		name:                 ops.name,
+		name:                 ops.Name(),
 		rowGroupSize:         ops.rowGroupSize,
 		numRowGroups:         ops.numRowGroups,
 		currentShard:         0,

--- a/convert/writer.go
+++ b/convert/writer.go
@@ -55,7 +55,7 @@ func NewShardedWrite(
 	opts *convertOpts,
 ) *ShardedWriter {
 	return &ShardedWriter{
-		name:                 opts.Name(),
+		name:                 opts.name,
 		rowGroupSize:         opts.rowGroupSize,
 		numRowGroups:         opts.numRowGroups,
 		currentShard:         0,

--- a/convert/writer_test.go
+++ b/convert/writer_test.go
@@ -88,7 +88,7 @@ func TestParquetWriter(t *testing.T) {
 	fChunks := make([][]chunks.Meta, 0, totalNumberOfSeries)
 
 	for i := 0; i < totalShards; i++ {
-		labelsFileName := schema.LabelsPfileNameForShard(convertsOpts.name, i)
+		labelsFileName := schema.LabelsPfileNameForShard(convertsOpts.Name(), i)
 		labelsAttr, err := bkt.Attributes(ctx, labelsFileName)
 		require.NoError(t, err)
 
@@ -121,7 +121,7 @@ func TestParquetWriter(t *testing.T) {
 			require.Len(t, chunk, 0)
 		}
 
-		chunksFileName := schema.ChunksPfileNameForShard(convertsOpts.name, i)
+		chunksFileName := schema.ChunksPfileNameForShard(convertsOpts.Name(), i)
 		chunksAttr, err := bkt.Attributes(ctx, chunksFileName)
 		require.NoError(t, err)
 

--- a/convert/writer_test.go
+++ b/convert/writer_test.go
@@ -76,9 +76,8 @@ func TestParquetWriter(t *testing.T) {
 		labelsProjection, chunksProjection,
 	}
 
-	writeFunc := PipeReaderBucketWriteFunc(bkt)
-
-	sw := NewShardedWrite(rr, rr.tsdbSchema, outSchemaProjections, writeFunc, &convertsOpts)
+	pipeReaderWriter := NewPipeReaderBucketWriter(bkt)
+	sw := NewShardedWrite(rr, rr.tsdbSchema, outSchemaProjections, pipeReaderWriter, &convertsOpts)
 	err = sw.Write(ctx)
 	require.NoError(t, err)
 
@@ -176,9 +175,8 @@ func Test_ShouldRespectContextCancellation(t *testing.T) {
 		}),
 	}
 
-	writeFunc := PipeReaderBucketWriteFunc(bkt)
-
-	sw, err := newSplitFileWriter(ctx, s.Schema, map[string]*schema.TSDBProjection{"test": s}, writeFunc)
+	pipeReaderWriter := NewPipeReaderBucketWriter(bkt)
+	sw, err := newSplitFileWriter(ctx, s.Schema, map[string]*schema.TSDBProjection{"test": s}, pipeReaderWriter)
 	require.NoError(t, err)
 	require.ErrorIs(t, sw.Close(), context.Canceled)
 }

--- a/convert/writer_test.go
+++ b/convert/writer_test.go
@@ -76,7 +76,9 @@ func TestParquetWriter(t *testing.T) {
 		labelsProjection, chunksProjection,
 	}
 
-	sw := NewShardedWrite(rr, rr.tsdbSchema, outSchemaProjections, bkt, &convertsOpts)
+	writeFunc := PipeReaderBucketWriteFunc(bkt)
+
+	sw := NewShardedWrite(rr, rr.tsdbSchema, outSchemaProjections, writeFunc, &convertsOpts)
 	err = sw.Write(ctx)
 	require.NoError(t, err)
 
@@ -174,7 +176,9 @@ func Test_ShouldRespectContextCancellation(t *testing.T) {
 		}),
 	}
 
-	sw, err := newSplitFileWriter(ctx, bkt, s.Schema, map[string]*schema.TSDBProjection{"test": s})
+	writeFunc := PipeReaderBucketWriteFunc(bkt)
+
+	sw, err := newSplitFileWriter(ctx, s.Schema, map[string]*schema.TSDBProjection{"test": s}, writeFunc)
 	require.NoError(t, err)
 	require.ErrorIs(t, sw.Close(), context.Canceled)
 }

--- a/convert/writer_test.go
+++ b/convert/writer_test.go
@@ -70,10 +70,7 @@ func TestParquetWriter(t *testing.T) {
 	}
 
 	require.NoError(t, app.Commit())
-
-	// head block can be re-used between tests cases;
-	// it is not consumed like an iterator and does not need to be closed or reset
-	h := st.Head()
+	h := st.Head() // head block can be re-used between test cases
 
 	convertsOpts := DefaultConvertOpts
 

--- a/convert/writer_test.go
+++ b/convert/writer_test.go
@@ -110,7 +110,7 @@ func TestParquetWriter(t *testing.T) {
 			fChunks := make([][]chunks.Meta, 0, totalNumberOfSeries)
 
 			for i := 0; i < totalShards; i++ {
-				labelsFileName := schema.LabelsPfileNameForShard(convertsOpts.Name(), i)
+				labelsFileName := schema.LabelsPfileNameForShard(convertsOpts.name, i)
 				labelsAttr, err := bkt.Attributes(ctx, labelsFileName)
 				require.NoError(t, err)
 
@@ -143,7 +143,7 @@ func TestParquetWriter(t *testing.T) {
 					require.Len(t, chunk, 0)
 				}
 
-				chunksFileName := schema.ChunksPfileNameForShard(convertsOpts.Name(), i)
+				chunksFileName := schema.ChunksPfileNameForShard(convertsOpts.name, i)
 				chunksAttr, err := bkt.Attributes(ctx, chunksFileName)
 				require.NoError(t, err)
 

--- a/convert/writer_test.go
+++ b/convert/writer_test.go
@@ -68,7 +68,15 @@ func TestParquetWriter(t *testing.T) {
 	require.NoError(t, err)
 	defer func() { _ = rr.Close() }()
 
-	sw := NewShardedWrite(rr, rr.tsdbSchema, bkt, &convertsOpts)
+	labelsProjection, err := rr.Schema().LabelsProjection()
+	require.NoError(t, err)
+	chunksProjection, err := rr.Schema().ChunksProjection()
+	require.NoError(t, err)
+	outSchemaProjections := []*schema.TSDBProjection{
+		labelsProjection, chunksProjection,
+	}
+
+	sw := NewShardedWrite(rr, rr.tsdbSchema, outSchemaProjections, bkt, &convertsOpts)
 	err = sw.Write(ctx)
 	require.NoError(t, err)
 

--- a/convert/writer_test.go
+++ b/convert/writer_test.go
@@ -84,7 +84,7 @@ func TestParquetWriter(t *testing.T) {
 		labelsAttr, err := bkt.Attributes(ctx, labelsFileName)
 		require.NoError(t, err)
 
-		labelsFile, err := parquet.OpenFile(storage.NewBucketReadAt(ctx, labelsFileName, bkt), labelsAttr.Size)
+		labelsFile, err := parquet.OpenFile(storage.NewBucketReadAt(labelsFileName, bkt).WithContext(context.Background()), labelsAttr.Size)
 		require.NoError(t, err)
 
 		// Inspect row groups
@@ -117,7 +117,7 @@ func TestParquetWriter(t *testing.T) {
 		chunksAttr, err := bkt.Attributes(ctx, chunksFileName)
 		require.NoError(t, err)
 
-		chunksFile, err := parquet.OpenFile(storage.NewBucketReadAt(ctx, chunksFileName, bkt), chunksAttr.Size)
+		chunksFile, err := parquet.OpenFile(storage.NewBucketReadAt(chunksFileName, bkt).WithContext(context.Background()), chunksAttr.Size)
 		require.NoError(t, err)
 
 		// should have the same number of row groups

--- a/convert/writer_test.go
+++ b/convert/writer_test.go
@@ -34,16 +34,32 @@ import (
 )
 
 func TestParquetWriter(t *testing.T) {
-	ctx := context.Background()
-	st := teststorage.New(t)
-	t.Cleanup(func() { _ = st.Close() })
-
 	bkt, err := filesystem.NewBucket(t.TempDir())
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = bkt.Close() })
 
-	app := st.Appender(ctx)
+	pipeReaderBucketWriter := NewPipeReaderBucketWriter(bkt)
+	pipeReaderFileWriter := NewPipeReaderFileWriter(t.TempDir())
 
+	testCases := []struct {
+		name             string
+		pipeReaderWriter PipeReaderWriter
+	}{
+		{
+			name:             "bucketWriter",
+			pipeReaderWriter: pipeReaderBucketWriter,
+		},
+		{
+			name:             "fileWriter",
+			pipeReaderWriter: pipeReaderFileWriter,
+		},
+	}
+
+	ctx := context.Background()
+	st := teststorage.New(t)
+	t.Cleanup(func() { _ = st.Close() })
+
+	app := st.Appender(ctx)
 	totalNumberOfSeries := 1_150
 	for i := 0; i != totalNumberOfSeries; i++ {
 		for j := 0; j < 10; j++ {
@@ -54,6 +70,9 @@ func TestParquetWriter(t *testing.T) {
 	}
 
 	require.NoError(t, app.Commit())
+
+	// head block can be re-used between tests cases;
+	// it is not consumed like an iterator and does not need to be closed or reset
 	h := st.Head()
 
 	convertsOpts := DefaultConvertOpts
@@ -64,102 +83,106 @@ func TestParquetWriter(t *testing.T) {
 	convertsOpts.writeBufferSize = 10
 	convertsOpts.sortedLabels = []string{labels.MetricName, "bar"}
 
-	rr, err := NewTsdbRowReader(ctx, h.MinTime(), h.MaxTime(), (time.Minute * 10).Milliseconds(), []Convertible{h}, convertsOpts)
-	require.NoError(t, err)
-	defer func() { _ = rr.Close() }()
+	for _, testCase := range testCases {
+		testName := fmt.Sprintf("pipeReaderWriter=%s", testCase.name)
+		t.Run(testName, func(t *testing.T) {
+			rr, err := NewTsdbRowReader(ctx, h.MinTime(), h.MaxTime(), (time.Minute * 10).Milliseconds(), []Convertible{h}, convertsOpts)
+			require.NoError(t, err)
+			defer func() { _ = rr.Close() }()
 
-	labelsProjection, err := rr.Schema().LabelsProjection()
-	require.NoError(t, err)
-	chunksProjection, err := rr.Schema().ChunksProjection()
-	require.NoError(t, err)
-	outSchemaProjections := []*schema.TSDBProjection{
-		labelsProjection, chunksProjection,
-	}
-
-	pipeReaderWriter := NewPipeReaderBucketWriter(bkt)
-	sw := NewShardedWrite(rr, rr.tsdbSchema, outSchemaProjections, pipeReaderWriter, &convertsOpts)
-	err = sw.Write(ctx)
-	require.NoError(t, err)
-
-	totalShards := int(math.Ceil(float64(totalNumberOfSeries) / float64(convertsOpts.numRowGroups*convertsOpts.rowGroupSize)))
-	remainingRows := totalNumberOfSeries
-	chunksDecoder := schema.NewPrometheusParquetChunksDecoder(chunkenc.NewPool())
-	buf := make([]parquet.Row, totalNumberOfSeries)
-	fSeries := make([]labels.Labels, 0, totalNumberOfSeries)
-	fChunks := make([][]chunks.Meta, 0, totalNumberOfSeries)
-
-	for i := 0; i < totalShards; i++ {
-		labelsFileName := schema.LabelsPfileNameForShard(convertsOpts.Name(), i)
-		labelsAttr, err := bkt.Attributes(ctx, labelsFileName)
-		require.NoError(t, err)
-
-		labelsFile, err := parquet.OpenFile(storage.NewBucketReadAt(labelsFileName, bkt).WithContext(context.Background()), labelsAttr.Size)
-		require.NoError(t, err)
-
-		// Inspect row groups
-		for _, group := range labelsFile.RowGroups() {
-			require.LessOrEqual(t, group.NumRows(), int64(convertsOpts.rowGroupSize))
-			for i, sortingCol := range convertsOpts.buildSortingColumns() {
-				require.Equal(t, sortingCol.Path(), group.SortingColumns()[i].Path())
-				require.Equal(t, sortingCol.Descending(), group.SortingColumns()[i].Descending())
-				require.Equal(t, sortingCol.NullsFirst(), group.SortingColumns()[i].NullsFirst())
+			labelsProjection, err := rr.Schema().LabelsProjection()
+			require.NoError(t, err)
+			chunksProjection, err := rr.Schema().ChunksProjection()
+			require.NoError(t, err)
+			outSchemaProjections := []*schema.TSDBProjection{
+				labelsProjection, chunksProjection,
 			}
-		}
 
-		lr := parquet.NewGenericReader[any](labelsFile)
-		n, err := lr.ReadRows(buf)
-		// Read the whole file
-		require.ErrorIs(t, err, io.EOF)
-		require.Equal(t, math.Min(float64(remainingRows), float64(convertsOpts.numRowGroups*convertsOpts.rowGroupSize)), float64(n))
+			sw := NewShardedWrite(rr, rr.tsdbSchema, outSchemaProjections, testCase.pipeReaderWriter, &convertsOpts)
+			err = sw.Write(ctx)
+			require.NoError(t, err)
 
-		series, chunks, err := rowToSeries(t, labelsFile.Schema(), chunksDecoder, buf[:n])
-		require.NoError(t, err)
-		require.Len(t, series, n)
-		require.Len(t, chunks, n)
-		fSeries = append(fSeries, series...)
-		// Should not have any chunk data on the labels file
-		for _, chunk := range chunks {
-			require.Len(t, chunk, 0)
-		}
+			totalShards := int(math.Ceil(float64(totalNumberOfSeries) / float64(convertsOpts.numRowGroups*convertsOpts.rowGroupSize)))
+			remainingRows := totalNumberOfSeries
+			chunksDecoder := schema.NewPrometheusParquetChunksDecoder(chunkenc.NewPool())
+			buf := make([]parquet.Row, totalNumberOfSeries)
+			fSeries := make([]labels.Labels, 0, totalNumberOfSeries)
+			fChunks := make([][]chunks.Meta, 0, totalNumberOfSeries)
 
-		chunksFileName := schema.ChunksPfileNameForShard(convertsOpts.Name(), i)
-		chunksAttr, err := bkt.Attributes(ctx, chunksFileName)
-		require.NoError(t, err)
+			for i := 0; i < totalShards; i++ {
+				labelsFileName := schema.LabelsPfileNameForShard(convertsOpts.Name(), i)
+				labelsAttr, err := bkt.Attributes(ctx, labelsFileName)
+				require.NoError(t, err)
 
-		chunksFile, err := parquet.OpenFile(storage.NewBucketReadAt(chunksFileName, bkt).WithContext(context.Background()), chunksAttr.Size)
-		require.NoError(t, err)
+				labelsFile, err := parquet.OpenFile(storage.NewBucketReadAt(labelsFileName, bkt).WithContext(context.Background()), labelsAttr.Size)
+				require.NoError(t, err)
 
-		// should have the same number of row groups
-		require.Equal(t, len(chunksFile.RowGroups()), len(chunksFile.RowGroups()))
+				// Inspect row groups
+				for _, group := range labelsFile.RowGroups() {
+					require.LessOrEqual(t, group.NumRows(), int64(convertsOpts.rowGroupSize))
+					for i, sortingCol := range convertsOpts.buildSortingColumns() {
+						require.Equal(t, sortingCol.Path(), group.SortingColumns()[i].Path())
+						require.Equal(t, sortingCol.Descending(), group.SortingColumns()[i].Descending())
+						require.Equal(t, sortingCol.NullsFirst(), group.SortingColumns()[i].NullsFirst())
+					}
+				}
 
-		cr := parquet.NewGenericReader[any](chunksFile)
-		n, err = cr.ReadRows(buf)
-		// Read the whole file
-		require.ErrorIs(t, err, io.EOF)
-		require.Equal(t, math.Min(float64(remainingRows), float64(convertsOpts.numRowGroups*convertsOpts.rowGroupSize)), float64(n))
+				lr := parquet.NewGenericReader[any](labelsFile)
+				n, err := lr.ReadRows(buf)
+				// Read the whole file
+				require.ErrorIs(t, err, io.EOF)
+				require.Equal(t, math.Min(float64(remainingRows), float64(convertsOpts.numRowGroups*convertsOpts.rowGroupSize)), float64(n))
 
-		series, chunks, err = rowToSeries(t, chunksFile.Schema(), chunksDecoder, buf[:n])
-		require.NoError(t, err)
-		require.Len(t, series, n)
-		require.Len(t, chunks, n)
-		fChunks = append(fChunks, chunks...)
+				series, chunks, err := rowToSeries(t, labelsFile.Schema(), chunksDecoder, buf[:n])
+				require.NoError(t, err)
+				require.Len(t, series, n)
+				require.Len(t, chunks, n)
+				fSeries = append(fSeries, series...)
+				// Should not have any chunk data on the labels file
+				for _, chunk := range chunks {
+					require.Len(t, chunk, 0)
+				}
 
-		// Should not have any label
-		for _, l := range series {
-			require.Len(t, l, 0)
-		}
+				chunksFileName := schema.ChunksPfileNameForShard(convertsOpts.Name(), i)
+				chunksAttr, err := bkt.Attributes(ctx, chunksFileName)
+				require.NoError(t, err)
 
-		remainingRows -= n
-	}
-	require.Len(t, fSeries, totalNumberOfSeries)
-	require.Len(t, fChunks, totalNumberOfSeries)
+				chunksFile, err := parquet.OpenFile(storage.NewBucketReadAt(chunksFileName, bkt).WithContext(context.Background()), chunksAttr.Size)
+				require.NoError(t, err)
 
-	// make sure the series are sorted
-	for i := 0; i < len(fSeries)-1; i++ {
-		require.LessOrEqual(t, fSeries[i].Get(labels.MetricName), fSeries[i+1].Get(labels.MetricName))
-		if fSeries[i].Get(labels.MetricName) == fSeries[i+1].Get(labels.MetricName) {
-			require.LessOrEqual(t, fSeries[i].Get("bar"), fSeries[i+1].Get("bar"))
-		}
+				// should have the same number of row groups
+				require.Equal(t, len(chunksFile.RowGroups()), len(chunksFile.RowGroups()))
+
+				cr := parquet.NewGenericReader[any](chunksFile)
+				n, err = cr.ReadRows(buf)
+				// Read the whole file
+				require.ErrorIs(t, err, io.EOF)
+				require.Equal(t, math.Min(float64(remainingRows), float64(convertsOpts.numRowGroups*convertsOpts.rowGroupSize)), float64(n))
+
+				series, chunks, err = rowToSeries(t, chunksFile.Schema(), chunksDecoder, buf[:n])
+				require.NoError(t, err)
+				require.Len(t, series, n)
+				require.Len(t, chunks, n)
+				fChunks = append(fChunks, chunks...)
+
+				// Should not have any label
+				for _, l := range series {
+					require.Len(t, l, 0)
+				}
+
+				remainingRows -= n
+			}
+			require.Len(t, fSeries, totalNumberOfSeries)
+			require.Len(t, fChunks, totalNumberOfSeries)
+
+			// make sure the series are sorted
+			for i := 0; i < len(fSeries)-1; i++ {
+				require.LessOrEqual(t, fSeries[i].Get(labels.MetricName), fSeries[i+1].Get(labels.MetricName))
+				if fSeries[i].Get(labels.MetricName) == fSeries[i+1].Get(labels.MetricName) {
+					require.LessOrEqual(t, fSeries[i].Get("bar"), fSeries[i+1].Get("bar"))
+				}
+			}
+		})
 	}
 }
 

--- a/schema/encoder_test.go
+++ b/schema/encoder_test.go
@@ -18,14 +18,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/prometheus/prometheus/tsdb/tsdbutil"
-
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql/promqltest"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
 	"github.com/prometheus/prometheus/tsdb/chunks"
 	"github.com/prometheus/prometheus/tsdb/index"
+	"github.com/prometheus/prometheus/tsdb/tsdbutil"
 	"github.com/stretchr/testify/require"
 )
 

--- a/schema/schema_builder.go
+++ b/schema/schema_builder.go
@@ -129,6 +129,7 @@ type TSDBSchema struct {
 }
 
 type TSDBProjection struct {
+	FilenameFunc func(name string, shard int) string
 	Schema       *parquet.Schema
 	ExtraOptions []parquet.WriterOption
 }
@@ -163,6 +164,9 @@ func (s *TSDBSchema) LabelsProjection() (*TSDBProjection, error) {
 		g[c[0]] = lc.Node
 	}
 	return &TSDBProjection{
+		FilenameFunc: func(name string, shard int) string {
+			return LabelsPfileNameForShard(name, shard)
+		},
 		Schema:       WithCompression(parquet.NewSchema("labels-projection", g)),
 		ExtraOptions: []parquet.WriterOption{parquet.SkipPageBounds(ColIndexes)},
 	}, nil
@@ -185,6 +189,9 @@ func (s *TSDBSchema) ChunksProjection() (*TSDBProjection, error) {
 	}
 
 	return &TSDBProjection{
+		FilenameFunc: func(name string, shard int) string {
+			return ChunksPfileNameForShard(name, shard)
+		},
 		Schema:       WithCompression(parquet.NewSchema("chunk-projection", g)),
 		ExtraOptions: writeOptions,
 	}, nil

--- a/search/constraint_test.go
+++ b/search/constraint_test.go
@@ -46,7 +46,7 @@ func buildFile[T any](t testing.TB, rows []T) *storage.ParquetFile {
 	reader := bytes.NewReader(buf.Bytes())
 	require.NoError(t, bkt.Upload(context.Background(), "pipe", reader))
 
-	f, err := storage.OpenFile(storage.NewBucketReadAt(context.Background(), "pipe", bkt), int64(len(buf.Bytes())), storage.WithFileOptions(parquet.ReadBufferSize(1)))
+	f, err := storage.OpenFile(context.Background(), storage.NewBucketReadAt("pipe", bkt), int64(len(buf.Bytes())), storage.WithFileOptions(parquet.ReadBufferSize(1)))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/search/constraint_test.go
+++ b/search/constraint_test.go
@@ -46,7 +46,7 @@ func buildFile[T any](t testing.TB, rows []T) *storage.ParquetFile {
 	reader := bytes.NewReader(buf.Bytes())
 	require.NoError(t, bkt.Upload(context.Background(), "pipe", reader))
 
-	f, err := storage.OpenFile(context.Background(), storage.NewBucketReadAt("pipe", bkt), int64(len(buf.Bytes())), storage.WithFileOptions(parquet.ReadBufferSize(1)))
+	f, err := storage.OpenFromBucket(context.Background(), bkt, "pipe", storage.WithFileOptions(parquet.ReadBufferSize(1)))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/search/materialize.go
+++ b/search/materialize.go
@@ -35,7 +35,7 @@ import (
 )
 
 type Materializer struct {
-	b           *storage.ParquetShard
+	b           storage.ParquetShard
 	s           *schema.TSDBSchema
 	d           *schema.PrometheusParquetChunksDecoder
 	partitioner util.Partitioner
@@ -48,7 +48,7 @@ type Materializer struct {
 
 func NewMaterializer(s *schema.TSDBSchema,
 	d *schema.PrometheusParquetChunksDecoder,
-	block *storage.ParquetShard,
+	block storage.ParquetShard,
 	concurrency int,
 	maxGapPartitioning int,
 ) (*Materializer, error) {

--- a/search/materialize_test.go
+++ b/search/materialize_test.go
@@ -212,7 +212,7 @@ func generateTestData(t *testing.T, st *teststorage.TestStorage, ctx context.Con
 	}
 }
 
-func convertToParquet(t *testing.T, ctx context.Context, bkt *bucket, data testData, h convert.Convertible, opts ...storage.ShardOption) *storage.ParquetShard {
+func convertToParquet(t *testing.T, ctx context.Context, bkt *bucket, data testData, h convert.Convertible, opts ...storage.ShardOption) storage.ParquetShard {
 	colDuration := time.Hour
 	shards, err := convert.ConvertTSDBBlock(
 		ctx,
@@ -234,7 +234,7 @@ func convertToParquet(t *testing.T, ctx context.Context, bkt *bucket, data testD
 	return shard
 }
 
-func query(t *testing.T, mint, maxt int64, shard *storage.ParquetShard, constraints ...Constraint) []prom_storage.ChunkSeries {
+func query(t *testing.T, mint, maxt int64, shard storage.ParquetShard, constraints ...Constraint) []prom_storage.ChunkSeries {
 	ctx := context.Background()
 	for _, c := range constraints {
 		require.NoError(t, c.init(shard.LabelsFile()))

--- a/search/materialize_test.go
+++ b/search/materialize_test.go
@@ -166,7 +166,7 @@ func convertToParquet(t *testing.T, ctx context.Context, bkt *bucket, data util.
 	require.Equal(t, 1, shards)
 
 	bucketOpener := storage.NewParquetBucketOpener(bkt)
-	shard, err := storage.NewParquetShardSyncOpener(
+	shard, err := storage.NewParquetShardOpener(
 		ctx, "shard", bucketOpener, bucketOpener, 0,
 	)
 	require.NoError(t, err)

--- a/search/materialize_test.go
+++ b/search/materialize_test.go
@@ -228,7 +228,7 @@ func convertToParquet(t *testing.T, ctx context.Context, bkt *bucket, data testD
 	require.NoError(t, err)
 	require.Equal(t, 1, shards)
 
-	shard, err := storage.OpenParquetShard(ctx, bkt, "shard", 0, opts...)
+	shard, err := storage.OpenParquetShardFromBucket(ctx, bkt, "shard", 0, opts...)
 	require.NoError(t, err)
 
 	return shard

--- a/search/materialize_test.go
+++ b/search/materialize_test.go
@@ -149,14 +149,6 @@ func TestMaterializeE2E(t *testing.T) {
 	})
 }
 
-type testConfig struct {
-	totalMetricNames     int
-	metricsPerMetricName int
-	numberOfLabels       int
-	randomLabels         int
-	numberOfSamples      int
-}
-
 func convertToParquet(t *testing.T, ctx context.Context, bkt *bucket, data util.TestData, h convert.Convertible, opts ...storage.ShardOption) storage.ParquetShard {
 	colDuration := time.Hour
 	shards, err := convert.ConvertTSDBBlock(

--- a/search/parquet_queryable.go
+++ b/search/parquet_queryable.go
@@ -30,7 +30,7 @@ import (
 	"github.com/prometheus-community/parquet-common/util"
 )
 
-type ShardsFinderFunction func(ctx context.Context, mint, maxt int64) ([]*storage.ParquetShard, error)
+type ShardsFinderFunction func(ctx context.Context, mint, maxt int64) ([]storage.ParquetShard, error)
 
 type queryableOpts struct {
 	concurrency                int
@@ -210,12 +210,12 @@ func (p parquetQuerier) queryableShards(ctx context.Context, mint, maxt int64) (
 }
 
 type queryableShard struct {
-	shard       *storage.ParquetShard
+	shard       storage.ParquetShard
 	m           *Materializer
 	concurrency int
 }
 
-func newQueryableShard(opts *queryableOpts, block *storage.ParquetShard, d *schema.PrometheusParquetChunksDecoder) (*queryableShard, error) {
+func newQueryableShard(opts *queryableOpts, block storage.ParquetShard, d *schema.PrometheusParquetChunksDecoder) (*queryableShard, error) {
 	s, err := block.TSDBSchema()
 	if err != nil {
 		return nil, err

--- a/search/parquet_queryable_test.go
+++ b/search/parquet_queryable_test.go
@@ -539,7 +539,10 @@ func convertToParquetForBench(tb testing.TB, ctx context.Context, bkt objstore.B
 		tb.Fatalf("expected 1 shard, got %d", shards)
 	}
 
-	shard, err := storage.OpenParquetShardFromBucket(ctx, bkt, "shard", 0, opts...)
+	bucketOpener := storage.NewParquetBucketOpener(bkt)
+	shard, err := storage.NewParquetShardSyncOpener(
+		ctx, "shard", bucketOpener, bucketOpener, 0,
+	)
 	if err != nil {
 		tb.Fatalf("error opening parquet shard: %v", err)
 	}

--- a/search/parquet_queryable_test.go
+++ b/search/parquet_queryable_test.go
@@ -318,7 +318,7 @@ eval instant at 60s http_requests_total{route=~".+"}
 	})
 }
 
-func queryWithQueryable(t *testing.T, mint, maxt int64, shard *storage.ParquetShard, hints *prom_storage.SelectHints, matchers ...*labels.Matcher) []prom_storage.Series {
+func queryWithQueryable(t *testing.T, mint, maxt int64, shard storage.ParquetShard, hints *prom_storage.SelectHints, matchers ...*labels.Matcher) []prom_storage.Series {
 	ctx := context.Background()
 	queryable, err := createQueryable(shard)
 	require.NoError(t, err)
@@ -333,10 +333,10 @@ func queryWithQueryable(t *testing.T, mint, maxt int64, shard *storage.ParquetSh
 	return found
 }
 
-func createQueryable(shard *storage.ParquetShard) (prom_storage.Queryable, error) {
+func createQueryable(shard storage.ParquetShard) (prom_storage.Queryable, error) {
 	d := schema.NewPrometheusParquetChunksDecoder(chunkenc.NewPool())
-	return NewParquetQueryable(d, func(ctx context.Context, mint, maxt int64) ([]*storage.ParquetShard, error) {
-		return []*storage.ParquetShard{shard}, nil
+	return NewParquetQueryable(d, func(ctx context.Context, mint, maxt int64) ([]storage.ParquetShard, error) {
+		return []storage.ParquetShard{shard}, nil
 	})
 }
 
@@ -518,7 +518,7 @@ func BenchmarkSelect(b *testing.B) {
 	}
 }
 
-func convertToParquetForBench(tb testing.TB, ctx context.Context, bkt objstore.Bucket, data testData, h convert.Convertible, opts ...storage.ShardOption) *storage.ParquetShard {
+func convertToParquetForBench(tb testing.TB, ctx context.Context, bkt objstore.Bucket, data testData, h convert.Convertible, opts ...storage.ShardOption) storage.ParquetShard {
 	colDuration := time.Hour
 	shards, err := convert.ConvertTSDBBlock(
 		ctx,
@@ -538,7 +538,7 @@ func convertToParquetForBench(tb testing.TB, ctx context.Context, bkt objstore.B
 		tb.Fatalf("expected 1 shard, got %d", shards)
 	}
 
-	shard, err := storage.OpenParquetShard(ctx, bkt, "shard", 0, opts...)
+	shard, err := storage.OpenParquetShardFromBucket(ctx, bkt, "shard", 0, opts...)
 	if err != nil {
 		tb.Fatalf("error opening parquet shard: %v", err)
 	}

--- a/search/parquet_queryable_test.go
+++ b/search/parquet_queryable_test.go
@@ -540,7 +540,7 @@ func convertToParquetForBench(tb testing.TB, ctx context.Context, bkt objstore.B
 	}
 
 	bucketOpener := storage.NewParquetBucketOpener(bkt)
-	shard, err := storage.NewParquetShardSyncOpener(
+	shard, err := storage.NewParquetShardOpener(
 		ctx, "shard", bucketOpener, bucketOpener, 0,
 	)
 	if err != nil {

--- a/search/parquet_queryable_test.go
+++ b/search/parquet_queryable_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/prometheus-community/parquet-common/convert"
 	"github.com/prometheus-community/parquet-common/schema"
 	"github.com/prometheus-community/parquet-common/storage"
+	"github.com/prometheus-community/parquet-common/util"
 )
 
 func TestPromQLAcceptance(t *testing.T) {
@@ -98,7 +99,7 @@ func (st *acceptanceTestStorage) Querier(from, to int64) (prom_storage.Querier, 
 	st.t.Cleanup(func() { _ = bkt.Close() })
 
 	h := st.st.Head()
-	data := testData{minTime: h.MinTime(), maxTime: h.MaxTime()}
+	data := util.TestData{MinTime: h.MinTime(), MaxTime: h.MaxTime()}
 	block := convertToParquet(st.t, context.Background(), bkt, data, h)
 
 	q, err := createQueryable(block)
@@ -150,8 +151,8 @@ func TestQueryable(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = bkt.Close() })
 
-	cfg := defaultTestConfig()
-	data := generateTestData(t, st, ctx, cfg)
+	cfg := util.DefaultTestConfig()
+	data := util.GenerateTestData(t, st, ctx, cfg)
 
 	ir, err := st.Head().Index()
 	require.NoError(t, err)
@@ -178,28 +179,28 @@ func TestQueryable(t *testing.T) {
 
 			t.Run("QueryByUniqueLabel", func(t *testing.T) {
 				matchers := []*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, "unique", "unique_0")}
-				sFound := queryWithQueryable(t, data.minTime, data.maxTime, shard, nil, matchers...)
+				sFound := queryWithQueryable(t, data.MinTime, data.MaxTime, shard, nil, matchers...)
 				totalFound := 0
 				for _, series := range sFound {
 					require.Equal(t, series.Labels().Get("unique"), "unique_0")
-					require.Contains(t, data.seriesHash, series.Labels().Hash())
+					require.Contains(t, data.SeriesHash, series.Labels().Hash())
 					totalFound++
 				}
-				require.Equal(t, cfg.totalMetricNames, totalFound)
+				require.Equal(t, cfg.TotalMetricNames, totalFound)
 			})
 
 			t.Run("QueryByMetricName", func(t *testing.T) {
 				for i := 0; i < 50; i++ {
-					name := fmt.Sprintf("metric_%d", rand.Int()%cfg.totalMetricNames)
+					name := fmt.Sprintf("metric_%d", rand.Int()%cfg.TotalMetricNames)
 					matchers := []*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, labels.MetricName, name)}
-					sFound := queryWithQueryable(t, data.minTime, data.maxTime, shard, nil, matchers...)
+					sFound := queryWithQueryable(t, data.MinTime, data.MaxTime, shard, nil, matchers...)
 					totalFound := 0
 					for _, series := range sFound {
 						totalFound++
 						require.Equal(t, series.Labels().Get(labels.MetricName), name)
-						require.Contains(t, data.seriesHash, series.Labels().Hash())
+						require.Contains(t, data.SeriesHash, series.Labels().Hash())
 					}
-					require.Equal(t, cfg.metricsPerMetricName, totalFound)
+					require.Equal(t, cfg.MetricsPerMetricName, totalFound)
 				}
 			})
 
@@ -208,20 +209,20 @@ func TestQueryable(t *testing.T) {
 				hints := &prom_storage.SelectHints{
 					Func: "series",
 				}
-				sFound := queryWithQueryable(t, data.minTime, data.maxTime, shard, hints, matchers...)
+				sFound := queryWithQueryable(t, data.MinTime, data.MaxTime, shard, hints, matchers...)
 				totalFound := 0
 				for _, series := range sFound {
 					totalFound++
 					require.Equal(t, series.Labels().Get("unique"), "unique_0")
-					require.Contains(t, data.seriesHash, series.Labels().Hash())
+					require.Contains(t, data.SeriesHash, series.Labels().Hash())
 				}
-				require.Equal(t, cfg.totalMetricNames, totalFound)
+				require.Equal(t, cfg.TotalMetricNames, totalFound)
 			})
 
 			t.Run("LabelNames", func(t *testing.T) {
 				queryable, err := createQueryable(shard)
 				require.NoError(t, err)
-				querier, err := queryable.Querier(data.minTime, data.maxTime)
+				querier, err := queryable.Querier(data.MinTime, data.MaxTime)
 				require.NoError(t, err)
 
 				t.Run("Without Matchers", func(t *testing.T) {
@@ -246,7 +247,7 @@ func TestQueryable(t *testing.T) {
 			t.Run("LabelValues", func(t *testing.T) {
 				queryable, err := createQueryable(shard)
 				require.NoError(t, err)
-				querier, err := queryable.Querier(data.minTime, data.maxTime)
+				querier, err := queryable.Querier(data.MinTime, data.MaxTime)
 				require.NoError(t, err)
 				t.Run("Without Matchers", func(t *testing.T) {
 					lValues, _, err := querier.LabelValues(context.Background(), labels.MetricName, nil)
@@ -481,7 +482,7 @@ func BenchmarkSelect(b *testing.B) {
 	require.Equal(b, totalSeries, int(h.NumSeries()), "Expected number of series does not match")
 
 	cbkt := &countingBucket{Bucket: bkt}
-	data := testData{minTime: h.MinTime(), maxTime: h.MaxTime()}
+	data := util.TestData{MinTime: h.MinTime(), MaxTime: h.MaxTime()}
 	block := convertToParquetForBench(b, ctx, cbkt, data, h)
 	queryable, err := createQueryable(block)
 	require.NoError(b, err, "unable to create queryable")
@@ -518,13 +519,13 @@ func BenchmarkSelect(b *testing.B) {
 	}
 }
 
-func convertToParquetForBench(tb testing.TB, ctx context.Context, bkt objstore.Bucket, data testData, h convert.Convertible, opts ...storage.ShardOption) storage.ParquetShard {
+func convertToParquetForBench(tb testing.TB, ctx context.Context, bkt objstore.Bucket, data util.TestData, h convert.Convertible, opts ...storage.ShardOption) storage.ParquetShard {
 	colDuration := time.Hour
 	shards, err := convert.ConvertTSDBBlock(
 		ctx,
 		bkt,
-		data.minTime,
-		data.maxTime,
+		data.MinTime,
+		data.MaxTime,
 		[]convert.Convertible{h},
 		convert.WithName("shard"),
 		convert.WithColDuration(colDuration),

--- a/storage/parquet_shard.go
+++ b/storage/parquet_shard.go
@@ -171,7 +171,7 @@ func OpenParquetShardFromBucket(ctx context.Context, bkt objstore.Bucket, name s
 	}, nil
 }
 
-func NewParquetShard(labelsFile, chunksFile *ParquetFile) *ParquetShardBucketLabelsAndChunks {
+func NewParquetShardBucketLabelsAndChunks(labelsFile, chunksFile *ParquetFile) *ParquetShardBucketLabelsAndChunks {
 	return &ParquetShardBucketLabelsAndChunks{
 		labelsFile: labelsFile,
 		chunksFile: chunksFile,

--- a/storage/parquet_shard.go
+++ b/storage/parquet_shard.go
@@ -164,20 +164,20 @@ func (o *ParquetLocalFileOpener) Open(ctx context.Context, name string, opts ...
 	return OpenFromFile(ctx, name, opts...)
 }
 
-type ParquetShardSyncOpener struct {
+type ParquetShardOpener struct {
 	labelsFile, chunksFile *ParquetFile
 	schema                 *schema.TSDBSchema
 	o                      sync.Once
 }
 
-func NewParquetShardSyncOpener(
+func NewParquetShardOpener(
 	ctx context.Context,
 	name string,
 	labelsFileOpener ParquetOpener,
 	chunksFileOpener ParquetOpener,
 	shard int,
 	opts ...ShardOption,
-) (*ParquetShardSyncOpener, error) {
+) (*ParquetShardOpener, error) {
 	labelsFileName := schema.LabelsPfileNameForShard(name, shard)
 	chunksFileName := schema.ChunksPfileNameForShard(name, shard)
 
@@ -199,21 +199,21 @@ func NewParquetShardSyncOpener(
 		return nil, err
 	}
 
-	return &ParquetShardSyncOpener{
+	return &ParquetShardOpener{
 		labelsFile: labelsFile,
 		chunksFile: chunksFile,
 	}, nil
 }
 
-func (s *ParquetShardSyncOpener) LabelsFile() *ParquetFile {
+func (s *ParquetShardOpener) LabelsFile() *ParquetFile {
 	return s.labelsFile
 }
 
-func (s *ParquetShardSyncOpener) ChunksFile() *ParquetFile {
+func (s *ParquetShardOpener) ChunksFile() *ParquetFile {
 	return s.chunksFile
 }
 
-func (s *ParquetShardSyncOpener) TSDBSchema() (*schema.TSDBSchema, error) {
+func (s *ParquetShardOpener) TSDBSchema() (*schema.TSDBSchema, error) {
 	var err error
 	s.o.Do(func() {
 		s.schema, err = schema.FromLabelsFile(s.labelsFile.File)
@@ -221,7 +221,7 @@ func (s *ParquetShardSyncOpener) TSDBSchema() (*schema.TSDBSchema, error) {
 	return s.schema, err
 }
 
-func (s *ParquetShardSyncOpener) Close() error {
+func (s *ParquetShardOpener) Close() error {
 	err := &multierror.Error{}
 	err = multierror.Append(err, s.labelsFile.Close())
 	err = multierror.Append(err, s.chunksFile.Close())

--- a/storage/parquet_shard.go
+++ b/storage/parquet_shard.go
@@ -146,7 +146,7 @@ func OpenParquetShardFromBucket(ctx context.Context, bkt objstore.Bucket, name s
 	var labelsFile, chunksFile *ParquetFile
 
 	errGroup.Go(func() (err error) {
-		chunksFile, err = OpenFromBucket(ctx, bkt, labelsFileName, opts...)
+		labelsFile, err = OpenFromBucket(ctx, bkt, labelsFileName, opts...)
 		return err
 	})
 

--- a/storage/read_at.go
+++ b/storage/read_at.go
@@ -16,48 +16,72 @@ package storage
 import (
 	"context"
 	"io"
+	"os"
 
 	"github.com/thanos-io/objstore"
 )
 
-type ReadAtWithContext interface {
-	io.ReaderAt
+type ReadAtWithContextCloser interface {
+	io.Closer
 	WithContext(ctx context.Context) io.ReaderAt
+}
+
+type fileReadAt struct {
+	*os.File
+}
+
+// NewFileReadAt returns a ReadAtCloserWithContext for reading from a local file.
+func NewFileReadAt(path string) (ReadAtWithContextCloser, error) {
+	f, err := os.Open(path)
+	return &fileReadAt{
+		File: f,
+	}, err
+}
+
+func (f *fileReadAt) WithContext(_ context.Context) io.ReaderAt {
+	return f.File
 }
 
 type bReadAt struct {
 	path string
-	obj  objstore.Bucket
-	ctx  context.Context
+	obj  objstore.BucketReader
 }
 
-func NewBucketReadAt(ctx context.Context, path string, obj objstore.Bucket) ReadAtWithContext {
+// NewBucketReadAt returns a ReadAtWithContextCloser for reading from a bucket.
+func NewBucketReadAt(path string, obj objstore.BucketReader) ReadAtWithContextCloser {
 	return &bReadAt{
 		path: path,
 		obj:  obj,
-		ctx:  ctx,
 	}
 }
 
 func (b *bReadAt) WithContext(ctx context.Context) io.ReaderAt {
-	return &bReadAt{
-		path: b.path,
-		obj:  b.obj,
-		ctx:  ctx,
+	return readAtFunc{
+		f: func(p []byte, off int64) (n int, err error) {
+			rc, err := b.obj.GetRange(ctx, b.path, off, int64(len(p)))
+			if err != nil {
+				return 0, err
+			}
+			defer func() { _ = rc.Close() }()
+			n, err = io.ReadFull(rc, p)
+			if err == io.EOF {
+				err = nil
+			}
+			return
+		},
 	}
 }
 
-func (b *bReadAt) ReadAt(p []byte, off int64) (n int, err error) {
-	rc, err := b.obj.GetRange(b.ctx, b.path, off, int64(len(p)))
-	if err != nil {
-		return 0, err
-	}
-	defer func() { _ = rc.Close() }()
-	n, err = io.ReadFull(rc, p)
-	if err == io.EOF {
-		err = nil
-	}
-	return
+func (b *bReadAt) Close() error {
+	return nil
+}
+
+type readAtFunc struct {
+	f func([]byte, int64) (n int, err error)
+}
+
+func (r readAtFunc) ReadAt(p []byte, off int64) (n int, err error) {
+	return r.f(p, off)
 }
 
 type optimisticReaderAt struct {

--- a/storage/read_at.go
+++ b/storage/read_at.go
@@ -31,11 +31,10 @@ type fileReadAt struct {
 }
 
 // NewFileReadAt returns a ReadAtCloserWithContext for reading from a local file.
-func NewFileReadAt(path string) (ReadAtWithContextCloser, error) {
-	f, err := os.Open(path)
+func NewFileReadAt(f *os.File) ReadAtWithContextCloser {
 	return &fileReadAt{
 		File: f,
-	}, err
+	}
 }
 
 func (f *fileReadAt) WithContext(_ context.Context) io.ReaderAt {

--- a/storage/read_at_test.go
+++ b/storage/read_at_test.go
@@ -83,7 +83,7 @@ func TestBucketReadAtWithLimitedReader(t *testing.T) {
 	// Create test data that's longer than our limited reader's chunk size
 	testData := []byte("Hello, this is a test string that is longer than 2 bytes")
 	bucket := &mockBucket{content: testData}
-	reader := NewBucketReadAt(context.Background(), "test", bucket)
+	reader := NewBucketReadAt("test", bucket).WithContext(context.Background())
 
 	// Test reading the entire content
 	buf := make([]byte, len(testData))

--- a/util/fixtures.go
+++ b/util/fixtures.go
@@ -1,0 +1,77 @@
+package util
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/util/teststorage"
+	"github.com/stretchr/testify/require"
+)
+
+type TestConfig struct {
+	TotalMetricNames     int
+	MetricsPerMetricName int
+	NumberOfLabels       int
+	RandomLabels         int
+	NumberOfSamples      int
+}
+
+func DefaultTestConfig() TestConfig {
+	return TestConfig{
+		TotalMetricNames:     1_000,
+		MetricsPerMetricName: 20,
+		NumberOfLabels:       5,
+		RandomLabels:         3,
+		NumberOfSamples:      250,
+	}
+}
+
+type TestData struct {
+	SeriesHash map[uint64]*struct{}
+	MinTime    int64
+	MaxTime    int64
+}
+
+func GenerateTestData(t *testing.T, st *teststorage.TestStorage, ctx context.Context, cfg TestConfig) TestData {
+	app := st.Appender(ctx)
+	seriesHash := make(map[uint64]*struct{})
+	builder := labels.NewScratchBuilder(cfg.NumberOfLabels)
+
+	for i := 0; i < cfg.TotalMetricNames; i++ {
+		for n := 0; n < cfg.MetricsPerMetricName; n++ {
+			builder.Reset()
+			builder.Add(labels.MetricName, fmt.Sprintf("metric_%d", i))
+			builder.Add("unique", fmt.Sprintf("unique_%d", n))
+
+			for j := 0; j < cfg.NumberOfLabels; j++ {
+				builder.Add(fmt.Sprintf("label_name_%v", j), fmt.Sprintf("label_value_%v", j))
+			}
+
+			firstRandom := rand.Int() % 10
+			for k := firstRandom; k < firstRandom+cfg.RandomLabels; k++ {
+				builder.Add(fmt.Sprintf("random_name_%v", k), fmt.Sprintf("random_value_%v", k))
+			}
+
+			builder.Sort()
+			lbls := builder.Labels()
+			seriesHash[lbls.Hash()] = &struct{}{}
+			for s := 0; s < cfg.NumberOfSamples; s++ {
+				_, err := app.Append(0, lbls, (1 * time.Minute * time.Duration(s)).Milliseconds(), float64(i))
+				require.NoError(t, err)
+			}
+		}
+	}
+
+	require.NoError(t, app.Commit())
+	h := st.Head()
+
+	return TestData{
+		SeriesHash: seriesHash,
+		MinTime:    h.MinTime(),
+		MaxTime:    h.MaxTime(),
+	}
+}


### PR DESCRIPTION
## Goal
The goal from my end here is to ultimately be able to query the Parquet shards from local disk as well as object storage -  the second option in this matrix.
| labels  | chunks  | use  |
|---|---|---|
| bucket | bucket | resolve queries without local disk usage|
| local | bucket | resolve labels files search faster (trade off disk space) |
|  bucket | local | N/A - do not see use for this |
| local | local | N/A - do not see use for this |

## Summary of Changes

### Re-use of `convert.ShardedWriter` to download already-converted shard files from bucket to disk
Just to get the files from bucket to disk we do not need to convert or transform, but the components in the `convert` package offer really nice plumbing  for buffering and schema validation for the download. Re-using this allows us to avoid re-inventing these functions just to download the files.

So we want enable a 1:1 "conversion" of labels file in bucket to local labels file.
To handle this, I parameterized the output schema projections rather than having them hardcoded by the `ShardedWriter.transformations` method.
So:
* The existing use case of `ConvertTSDBBlock` to convert standard TSDB blocks to -> two-files in the bucket uses the TSDB rowreader and provides two output schema projections.
* The new case, a simple download of labels file in bucket to labels file locally uses a labels file bucket rowreader and provides the existing labels file schema as the only output schema projection.

Finally I parameterized the final write destination. Instead of a hardcoded `bkt.Upload(ctx, file, r)`, this introduces the `PipeReaderWriter` interface to read from the piped data from the rowreader.

### Ability to open the parquet shard files separately, one from local disk and another from bucket
These openers are what are utilized to open the shard files and ultimately return the opened shards from the `ShardsFinderFunction` to the queryable.

```golang
func OpenParquetShard(ctx context.Context, bkt objstore.Bucket, name string, shard int, opts ...ShardOption) (*ParquetShard, error) {
```
has become
```golang
func NewParquetShardSyncOpener(
	ctx context.Context,
	name string,
	labelsFileOpener ParquetOpener,
	chunksFileOpener ParquetOpener,
	shard int,
	opts ...ShardOption,
) (*ParquetShardSyncOpener, error) {
```
Where each the `ParquetOpener` can be satisfied by either `ParquetBucketOpener` or `ParquetLocalFileOpener`. 

### Fix Race Condition in `bufferedReader.ReadRows`
Running a conversion on a large block was triggering data race detection as the `bufferedReader` was returning the same row slice to its memory pool as it was returning, and they were still getting read by the `splitPipeFileWriter.WriteRows` when the `bufferedReader` re-used them from the pool.
Fixed by actually cloning the row object instead of just sharing the backing memory between slices.


