### PR TITLE
search: Modify bucket implementation for benchmark

### DIFF
--- a/search/materialize_test.go
+++ b/search/materialize_test.go
@@ -26,11 +26,11 @@ import (
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
 	"github.com/prometheus/prometheus/util/teststorage"
 	"github.com/stretchr/testify/require"
-	"github.com/thanos-io/objstore/providers/filesystem"
 
 	"github.com/prometheus-community/parquet-common/convert"
 	"github.com/prometheus-community/parquet-common/schema"
 	"github.com/prometheus-community/parquet-common/storage"
+	"github.com/prometheus-community/parquet-common/util/filesystem"
 )
 
 func TestMaterializeE2E(t *testing.T) {

--- a/search/parquet_queryable_test.go
+++ b/search/parquet_queryable_test.go
@@ -33,11 +33,11 @@ import (
 	"github.com/prometheus/prometheus/util/testutil"
 	"github.com/stretchr/testify/require"
 	"github.com/thanos-io/objstore"
-	"github.com/thanos-io/objstore/providers/filesystem"
 
 	"github.com/prometheus-community/parquet-common/convert"
 	"github.com/prometheus-community/parquet-common/schema"
 	"github.com/prometheus-community/parquet-common/storage"
+	"github.com/prometheus-community/parquet-common/util/filesystem"
 )
 
 func TestPromQLAcceptance(t *testing.T) {

--- a/util/filesystem/filesystem.go
+++ b/util/filesystem/filesystem.go
@@ -1,0 +1,440 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// Provenance-includes-location: https://github.com/thanos-io/objstore/blob/71fdd5acb3633b26f88c75dd6768fdc2f9ec246b/providers/filesystem/filesystem.go
+// Provenance-includes-license: Apache-2.0
+// Provenance-includes-copyright: The Thanos Authors.
+
+package filesystem
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"github.com/efficientgo/core/errcapture"
+	"github.com/pkg/errors"
+	"gopkg.in/yaml.v2"
+
+	"github.com/thanos-io/objstore"
+)
+
+// Config stores the configuration for storing and accessing blobs in filesystem.
+type Config struct {
+	Directory string `yaml:"directory"`
+}
+
+// cachedFileInfo holds both the file descriptor and metadata to avoid repeated Stat() calls
+type cachedFileInfo struct {
+	file *os.File
+	size int64
+}
+
+// Bucket implements the objstore.Bucket interfaces against filesystem that binary runs on.
+// Methods from Bucket interface are thread-safe. Objects are assumed to be immutable.
+// NOTE: It does not follow symbolic links.
+type Bucket struct {
+	rootDir   string
+	fileCache map[string]*cachedFileInfo
+	mutex     sync.RWMutex
+}
+
+// NewBucketFromConfig returns a new filesystem.Bucket from config.
+func NewBucketFromConfig(conf []byte) (*Bucket, error) {
+	var c Config
+	if err := yaml.Unmarshal(conf, &c); err != nil {
+		return nil, err
+	}
+	if c.Directory == "" {
+		return nil, errors.New("missing directory for filesystem bucket")
+	}
+	return NewBucket(c.Directory)
+}
+
+// NewBucket returns a new filesystem.Bucket.
+func NewBucket(rootDir string) (*Bucket, error) {
+	absDir, err := filepath.Abs(rootDir)
+	if err != nil {
+		return nil, err
+	}
+	return &Bucket{
+		rootDir:   absDir,
+		fileCache: make(map[string]*cachedFileInfo),
+	}, nil
+}
+
+func (b *Bucket) Provider() objstore.ObjProvider { return objstore.FILESYSTEM }
+
+func (b *Bucket) SupportedIterOptions() []objstore.IterOptionType {
+	return []objstore.IterOptionType{objstore.Recursive, objstore.UpdatedAt}
+}
+
+func (b *Bucket) IterWithAttributes(ctx context.Context, dir string, f func(attrs objstore.IterObjectAttributes) error, options ...objstore.IterOption) error {
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+
+	if err := objstore.ValidateIterOptions(b.SupportedIterOptions(), options...); err != nil {
+		return err
+	}
+
+	params := objstore.ApplyIterOptions(options...)
+	absDir := filepath.Join(b.rootDir, dir)
+	info, err := os.Stat(absDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return errors.Wrapf(err, "stat %s", absDir)
+	}
+	if !info.IsDir() {
+		return nil
+	}
+
+	files, err := os.ReadDir(absDir)
+	if err != nil {
+		return err
+	}
+	for _, file := range files {
+		name := filepath.Join(dir, file.Name())
+
+		if file.IsDir() {
+			empty, err := isDirEmpty(filepath.Join(absDir, file.Name()))
+			if err != nil {
+				return err
+			}
+
+			if empty {
+				// Skip empty directories.
+				continue
+			}
+
+			name += objstore.DirDelim
+
+			if params.Recursive {
+				// Recursively list files in the subdirectory.
+				if err := b.IterWithAttributes(ctx, name, f, options...); err != nil {
+					return err
+				}
+
+				// The callback f() has already been called for the subdirectory
+				// files so we should skip to next filesystem entry.
+				continue
+			}
+		}
+
+		attrs := objstore.IterObjectAttributes{
+			Name: name,
+		}
+		if params.LastModified {
+			absPath := filepath.Join(absDir, file.Name())
+			stat, err := os.Stat(absPath)
+			if err != nil {
+				return errors.Wrapf(err, "stat %s", name)
+			}
+			attrs.SetLastModified(stat.ModTime())
+		}
+		if err := f(attrs); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Iter calls f for each entry in the given directory. The argument to f is the full
+// object name including the prefix of the inspected directory.
+func (b *Bucket) Iter(ctx context.Context, dir string, f func(string) error, opts ...objstore.IterOption) error {
+	// Only include recursive option since attributes are not used in this method.
+	var filteredOpts []objstore.IterOption
+	for _, opt := range opts {
+		if opt.Type == objstore.Recursive {
+			filteredOpts = append(filteredOpts, opt)
+			break
+		}
+	}
+
+	return b.IterWithAttributes(ctx, dir, func(attrs objstore.IterObjectAttributes) error {
+		return f(attrs.Name)
+	}, filteredOpts...)
+}
+
+// Get returns a reader for the given object name.
+func (b *Bucket) Get(ctx context.Context, name string) (io.ReadCloser, error) {
+	return b.GetRange(ctx, name, 0, -1)
+}
+
+// readAtReader implements io.ReadCloser using ReadAt with a cached file descriptor
+type readAtReader struct {
+	f      *os.File
+	offset int64
+	size   int64
+	pos    int64
+}
+
+func (r *readAtReader) Read(p []byte) (n int, err error) {
+	if r.pos >= r.size {
+		return 0, io.EOF
+	}
+
+	remaining := r.size - r.pos
+	if int64(len(p)) > remaining {
+		p = p[:remaining]
+	}
+
+	n, err = r.f.ReadAt(p, r.offset+r.pos)
+	r.pos += int64(n)
+
+	if r.pos >= r.size && err == nil {
+		err = io.EOF
+	}
+
+	return n, err
+}
+
+func (r *readAtReader) Close() error {
+	// Don't close the cached file descriptor
+	return nil
+}
+
+// Attributes returns information about the specified object.
+func (b *Bucket) Attributes(ctx context.Context, name string) (objstore.ObjectAttributes, error) {
+	if ctx.Err() != nil {
+		return objstore.ObjectAttributes{}, ctx.Err()
+	}
+
+	file := filepath.Join(b.rootDir, name)
+
+	// Check cache first
+	b.mutex.RLock()
+	cachedInfo, exists := b.fileCache[file]
+	b.mutex.RUnlock()
+
+	if exists {
+		// Use cached file size but we still need to stat for LastModified
+		// since that can change and we don't cache it
+		stat, err := os.Stat(file)
+		if err != nil {
+			return objstore.ObjectAttributes{}, errors.Wrapf(err, "stat %s", file)
+		}
+		return objstore.ObjectAttributes{
+			Size:         cachedInfo.size,
+			LastModified: stat.ModTime(),
+		}, nil
+	}
+
+	// Not in cache, do full stat
+	stat, err := os.Stat(file)
+	if err != nil {
+		return objstore.ObjectAttributes{}, errors.Wrapf(err, "stat %s", file)
+	}
+
+	return objstore.ObjectAttributes{
+		Size:         stat.Size(),
+		LastModified: stat.ModTime(),
+	}, nil
+}
+
+// GetRange returns a new range reader for the given object name and range.
+func (b *Bucket) GetRange(ctx context.Context, name string, off, length int64) (io.ReadCloser, error) {
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
+
+	if name == "" {
+		return nil, errors.New("object name is empty")
+	}
+
+	file := filepath.Join(b.rootDir, name)
+
+	// Check cache first
+	b.mutex.RLock()
+	cachedInfo, exists := b.fileCache[file]
+	b.mutex.RUnlock()
+
+	if !exists {
+		// File not in cache, stat it, open it, and add to cache
+		stat, err := os.Stat(file)
+		if err != nil {
+			return nil, errors.Wrapf(err, "stat %s", file)
+		}
+
+		f, err := os.OpenFile(filepath.Clean(file), os.O_RDONLY, 0600)
+		if err != nil {
+			return nil, err
+		}
+
+		info := &cachedFileInfo{
+			file: f,
+			size: stat.Size(),
+		}
+
+		b.mutex.Lock()
+		// Check again in case another goroutine added it while we were waiting for the lock
+		if existingInfo, alreadyExists := b.fileCache[file]; alreadyExists {
+			// Another goroutine already added it, close our copy and use the existing one
+			f.Close()
+			cachedInfo = existingInfo
+		} else {
+			// We're the first to add it to the cache
+			b.fileCache[file] = info
+			cachedInfo = info
+		}
+		b.mutex.Unlock()
+	}
+
+	// Calculate the size to read using cached file size
+	fileSize := cachedInfo.size
+	if off > fileSize {
+		off = fileSize
+	}
+
+	var readSize int64
+	if length == -1 {
+		readSize = fileSize - off
+	} else {
+		readSize = length
+		if off+readSize > fileSize {
+			readSize = fileSize - off
+		}
+	}
+
+	reader := &readAtReader{
+		f:      cachedInfo.file,
+		offset: off,
+		size:   readSize,
+		pos:    0,
+	}
+
+	return objstore.ObjectSizerReadCloser{
+		ReadCloser: reader,
+		Size: func() (int64, error) {
+			return readSize, nil
+		},
+	}, nil
+}
+
+// Exists checks if the given directory exists in memory.
+func (b *Bucket) Exists(ctx context.Context, name string) (bool, error) {
+	if ctx.Err() != nil {
+		return false, ctx.Err()
+	}
+
+	info, err := os.Stat(filepath.Join(b.rootDir, name))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, errors.Wrapf(err, "stat %s", filepath.Join(b.rootDir, name))
+	}
+	return !info.IsDir(), nil
+}
+
+// Upload writes the file specified in src to into the memory.
+func (b *Bucket) Upload(ctx context.Context, name string, r io.Reader, _ ...objstore.ObjectUploadOption) (err error) {
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+
+	file := filepath.Join(b.rootDir, name)
+	if err := os.MkdirAll(filepath.Dir(file), os.ModePerm); err != nil {
+		return err
+	}
+
+	f, err := os.Create(file)
+	if err != nil {
+		return err
+	}
+	defer errcapture.Do(&err, f.Close, "close")
+
+	if _, err := io.Copy(f, r); err != nil {
+		return errors.Wrapf(err, "copy to %s", file)
+	}
+	return nil
+}
+
+func isDirEmpty(name string) (ok bool, err error) {
+	f, err := os.Open(filepath.Clean(name))
+	if os.IsNotExist(err) {
+		// The directory doesn't exist. We don't consider it an error and we treat it like empty.
+		return true, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	defer errcapture.Do(&err, f.Close, "close dir")
+
+	if _, err = f.Readdir(1); err == io.EOF || os.IsNotExist(err) {
+		return true, nil
+	}
+	return false, err
+}
+
+// Delete removes all data prefixed with the dir.
+func (b *Bucket) Delete(ctx context.Context, name string) error {
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+
+	file := filepath.Join(b.rootDir, name)
+	for file != b.rootDir {
+		if err := os.RemoveAll(file); err != nil {
+			return errors.Wrapf(err, "rm %s", file)
+		}
+		file = filepath.Dir(file)
+		empty, err := isDirEmpty(file)
+		if err != nil {
+			return err
+		}
+		if !empty {
+			break
+		}
+	}
+	return nil
+}
+
+// IsObjNotFoundErr returns true if error means that object is not found. Relevant to Get operations.
+func (b *Bucket) IsObjNotFoundErr(err error) bool {
+	return os.IsNotExist(errors.Cause(err))
+}
+
+// IsAccessDeniedErr returns true if access to object is denied.
+func (b *Bucket) IsAccessDeniedErr(_ error) bool {
+	return false
+}
+
+func (b *Bucket) Close() error {
+	b.mutex.Lock()
+	defer b.mutex.Unlock()
+
+	var errs []error
+	for path, info := range b.fileCache {
+		if err := info.file.Close(); err != nil {
+			errs = append(errs, errors.Wrapf(err, "close cached file %s", path))
+		}
+	}
+
+	// Clear the cache
+	b.fileCache = make(map[string]*cachedFileInfo)
+
+	if len(errs) > 0 {
+		return fmt.Errorf("errors closing cached files: %v", errs)
+	}
+	return nil
+}
+
+// Name returns the bucket name.
+func (b *Bucket) Name() string {
+	return fmt.Sprintf("fs: %s", b.rootDir)
+}

--- a/util/filesystem/filesystem_test.go
+++ b/util/filesystem/filesystem_test.go
@@ -1,0 +1,205 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// Provenance-includes-location: https://github.com/thanos-io/objstore/blob/71fdd5acb3633b26f88c75dd6768fdc2f9ec246b/providers/filesystem/filesystem_test.go
+// Provenance-includes-license: Apache-2.0
+// Provenance-includes-copyright: The Thanos Authors.
+
+package filesystem
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/efficientgo/core/testutil"
+
+	"github.com/thanos-io/objstore"
+)
+
+func TestDelete_EmptyDirDeletionRaceCondition(t *testing.T) {
+	const runs = 1000
+
+	ctx := context.Background()
+
+	for r := 0; r < runs; r++ {
+		b, err := NewBucket(t.TempDir())
+		testutil.Ok(t, err)
+
+		// Upload 2 objects in a subfolder.
+		testutil.Ok(t, b.Upload(ctx, "subfolder/first", strings.NewReader("first")))
+		testutil.Ok(t, b.Upload(ctx, "subfolder/second", strings.NewReader("second")))
+
+		// Prepare goroutines to concurrently delete the 2 objects (each one deletes a different object)
+		start := make(chan struct{})
+		group := sync.WaitGroup{}
+		group.Add(2)
+
+		for _, object := range []string{"first", "second"} {
+			go func(object string) {
+				defer group.Done()
+
+				<-start
+				testutil.Ok(t, b.Delete(ctx, "subfolder/"+object))
+			}(object)
+		}
+
+		// Go!
+		close(start)
+		group.Wait()
+	}
+}
+
+func TestIter_CancelledContext(t *testing.T) {
+	b, err := NewBucket(t.TempDir())
+	testutil.Ok(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err = b.Iter(ctx, "", func(s string) error {
+		return nil
+	})
+
+	testutil.NotOk(t, err)
+	testutil.Equals(t, context.Canceled, err)
+}
+
+func TestIterWithAttributes(t *testing.T) {
+	dir := t.TempDir()
+	f, err := os.CreateTemp(dir, "test")
+	testutil.Ok(t, err)
+	defer f.Close()
+
+	stat, err := f.Stat()
+	testutil.Ok(t, err)
+
+	cases := []struct {
+		name              string
+		opts              []objstore.IterOption
+		expectedUpdatedAt time.Time
+	}{
+		{
+			name: "no options",
+			opts: nil,
+		},
+		{
+			name: "with updated at",
+			opts: []objstore.IterOption{
+				objstore.WithUpdatedAt(),
+			},
+			expectedUpdatedAt: stat.ModTime(),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			b, err := NewBucket(dir)
+			testutil.Ok(t, err)
+
+			var attrs objstore.IterObjectAttributes
+
+			ctx := context.Background()
+			err = b.IterWithAttributes(ctx, "", func(objectAttrs objstore.IterObjectAttributes) error {
+				attrs = objectAttrs
+				return nil
+			}, tc.opts...)
+
+			testutil.Ok(t, err)
+
+			lastModified, ok := attrs.LastModified()
+			if zero := tc.expectedUpdatedAt.IsZero(); zero {
+				testutil.Equals(t, false, ok)
+			} else {
+				testutil.Equals(t, true, ok)
+				testutil.Equals(t, tc.expectedUpdatedAt, lastModified)
+			}
+		})
+
+	}
+}
+
+func TestGet_CancelledContext(t *testing.T) {
+	b, err := NewBucket(t.TempDir())
+	testutil.Ok(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err = b.Get(ctx, "some-file")
+	testutil.NotOk(t, err)
+	testutil.Equals(t, context.Canceled, err)
+}
+
+func TestAttributes_CancelledContext(t *testing.T) {
+	b, err := NewBucket(t.TempDir())
+	testutil.Ok(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err = b.Attributes(ctx, "some-file")
+	testutil.NotOk(t, err)
+	testutil.Equals(t, context.Canceled, err)
+}
+
+func TestGetRange_CancelledContext(t *testing.T) {
+	b, err := NewBucket(t.TempDir())
+	testutil.Ok(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err = b.GetRange(ctx, "some-file", 0, 100)
+	testutil.NotOk(t, err)
+	testutil.Equals(t, context.Canceled, err)
+}
+
+func TestExists_CancelledContext(t *testing.T) {
+	b, err := NewBucket(t.TempDir())
+	testutil.Ok(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err = b.Exists(ctx, "some-file")
+	testutil.NotOk(t, err)
+	testutil.Equals(t, context.Canceled, err)
+}
+
+func TestUpload_CancelledContext(t *testing.T) {
+	b, err := NewBucket(t.TempDir())
+	testutil.Ok(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err = b.Upload(ctx, "some-file", bytes.NewReader([]byte("file content")))
+	testutil.NotOk(t, err)
+	testutil.Equals(t, context.Canceled, err)
+}
+
+func TestDelete_CancelledContext(t *testing.T) {
+	b, err := NewBucket(t.TempDir())
+	testutil.Ok(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err = b.Delete(ctx, "some-file")
+	testutil.NotOk(t, err)
+	testutil.Equals(t, context.Canceled, err)
+}


### PR DESCRIPTION
Noticed that ~50% of the benchmark time was spent doing syscall.Open. The filesystem bucket implementation we're using comes from thanos/objstore repository so I decided to copy it over and cache the file descriptors so that we can run get_range calls in parallel without getting throttled by the syscalls.

**Profile data**
- Original profile of the benchmark: https://flamegraph.com/share/207b00b6-450d-11f0-b170-826a90ca3d79
- After modifications: https://flamegraph.com/share/1cf80ed4-453d-11f0-9c9f-da4acad57e16
- Comparison between the two: https://flamegraph.com/share/2ef55dd9-453d-11f0-b170-826a90ca3d79/2f0948b9-453d-11f0-b170-826a90ca3d79

**Benchmark data**

<details>
<summary>Click to view benchstat results</summary>

```
❯ benchstat with-filesystem-bucket.out with-custom-filesystem-bucket-and-less-open-and-stat-calls.out
goos: darwin
goarch: arm64
pkg: github.com/prometheus-community/parquet-common/search
cpu: Apple M2 Pro
                                        │ with-filesystem-bucket.out │ with-custom-filesystem-bucket-and-less-open-and-stat-calls.out │
                                        │           sec/op           │                 sec/op                   vs base               │
Select/SingleMetricAllSeries-12                         530.7m ± ∞ ¹                              355.1m ± ∞ ¹  -33.09% (p=0.008 n=5)
Select/SingleMetricReducedSeries-12                     85.02m ± ∞ ¹                              24.58m ± ∞ ¹  -71.09% (p=0.008 n=5)
Select/SingleMetricOneSeries-12                         78.48m ± ∞ ¹                              22.44m ± ∞ ¹  -71.40% (p=0.008 n=5)
Select/SingleMetricSparseSeries-12                     132.96m ± ∞ ¹                              45.12m ± ∞ ¹  -66.06% (p=0.008 n=5)
Select/NonExistentSeries-12                             77.35m ± ∞ ¹                              21.75m ± ∞ ¹  -71.87% (p=0.008 n=5)
Select/MultipleMetricsRange-12                           1.860 ± ∞ ¹                               1.596 ± ∞ ¹  -14.17% (p=0.008 n=5)
Select/MultipleMetricsSparse-12                         669.2m ± ∞ ¹                              468.1m ± ∞ ¹  -30.05% (p=0.008 n=5)
Select/NegativeRegexSingleMetric-12                     411.8m ± ∞ ¹                              335.0m ± ∞ ¹  -18.65% (p=0.008 n=5)
Select/NegativeRegexMultipleMetrics-12                   1.314 ± ∞ ¹                               1.010 ± ∞ ¹  -23.13% (p=0.008 n=5)
Select/ExpensiveRegexSingleMetric-12                   155.81m ± ∞ ¹                              55.06m ± ∞ ¹  -64.66% (p=0.008 n=5)
Select/ExpensiveRegexMultipleMetrics-12                 488.3m ± ∞ ¹                              145.7m ± ∞ ¹  -70.17% (p=0.008 n=5)
geomean                                                 301.4m                                    139.5m        -53.71%
¹ need >= 6 samples for confidence interval at level 0.95

                                        │ with-filesystem-bucket.out │ with-custom-filesystem-bucket-and-less-open-and-stat-calls.out │
                                        │     bytes_get_range/op     │           bytes_get_range/op            vs base                │
Select/SingleMetricAllSeries-12                         9.137M ± ∞ ¹                             9.137M ± ∞ ¹  +0.00% (p=0.008 n=5)
Select/SingleMetricReducedSeries-12                     2.029M ± ∞ ¹                             2.029M ± ∞ ¹  +0.00% (p=0.008 n=5)
Select/SingleMetricOneSeries-12                         1.978M ± ∞ ¹                             1.978M ± ∞ ¹  -0.00% (p=0.008 n=5)
Select/SingleMetricSparseSeries-12                      5.487M ± ∞ ¹                             5.487M ± ∞ ¹  +0.00% (p=0.008 n=5)
Select/NonExistentSeries-12                             1.939M ± ∞ ¹                             1.939M ± ∞ ¹       ~ (p=1.000 n=5) ²
Select/MultipleMetricsRange-12                          38.01M ± ∞ ¹                             38.01M ± ∞ ¹  +0.00% (p=0.008 n=5)
Select/MultipleMetricsSparse-12                         16.41M ± ∞ ¹                             16.41M ± ∞ ¹  +0.00% (p=0.008 n=5)
Select/NegativeRegexSingleMetric-12                     9.394M ± ∞ ¹                             9.394M ± ∞ ¹  +0.00% (p=0.008 n=5)
Select/NegativeRegexMultipleMetrics-12                  31.58M ± ∞ ¹                             31.58M ± ∞ ¹  -0.00% (p=0.008 n=5)
Select/ExpensiveRegexSingleMetric-12                    3.924M ± ∞ ¹                             3.924M ± ∞ ¹  -0.00% (p=0.008 n=5)
Select/ExpensiveRegexMultipleMetrics-12                 14.74M ± ∞ ¹                             14.74M ± ∞ ¹       ~ (p=1.000 n=5) ²
geomean                                                 7.492M                                   7.492M        +0.00%
¹ need >= 6 samples for confidence interval at level 0.95
² all samples are equal

                                        │ with-filesystem-bucket.out │ with-custom-filesystem-bucket-and-less-open-and-stat-calls.out │
                                        │           get/op           │                 get/op                  vs base                │
Select/SingleMetricAllSeries-12                          0.000 ± ∞ ¹                              0.000 ± ∞ ¹       ~ (p=1.000 n=5) ²
Select/SingleMetricReducedSeries-12                      0.000 ± ∞ ¹                              0.000 ± ∞ ¹       ~ (p=1.000 n=5) ²
Select/SingleMetricOneSeries-12                          0.000 ± ∞ ¹                              0.000 ± ∞ ¹       ~ (p=1.000 n=5) ²
Select/SingleMetricSparseSeries-12                       0.000 ± ∞ ¹                              0.000 ± ∞ ¹       ~ (p=1.000 n=5) ²
Select/NonExistentSeries-12                              0.000 ± ∞ ¹                              0.000 ± ∞ ¹       ~ (p=1.000 n=5) ²
Select/MultipleMetricsRange-12                           0.000 ± ∞ ¹                              0.000 ± ∞ ¹       ~ (p=1.000 n=5) ²
Select/MultipleMetricsSparse-12                          0.000 ± ∞ ¹                              0.000 ± ∞ ¹       ~ (p=1.000 n=5) ²
Select/NegativeRegexSingleMetric-12                      0.000 ± ∞ ¹                              0.000 ± ∞ ¹       ~ (p=1.000 n=5) ²
Select/NegativeRegexMultipleMetrics-12                   0.000 ± ∞ ¹                              0.000 ± ∞ ¹       ~ (p=1.000 n=5) ²
Select/ExpensiveRegexSingleMetric-12                     0.000 ± ∞ ¹                              0.000 ± ∞ ¹       ~ (p=1.000 n=5) ²
Select/ExpensiveRegexMultipleMetrics-12                  0.000 ± ∞ ¹                              0.000 ± ∞ ¹       ~ (p=1.000 n=5) ²
geomean                                                            ³                                           +0.00%               ³
¹ need >= 6 samples for confidence interval at level 0.95
² all samples are equal
³ summaries must be >0 to compute geomean

                                        │ with-filesystem-bucket.out │ with-custom-filesystem-bucket-and-less-open-and-stat-calls.out │
                                        │        get_range/op        │              get_range/op               vs base                │
Select/SingleMetricAllSeries-12                         19.16k ± ∞ ¹                             19.16k ± ∞ ¹       ~ (p=1.000 n=5) ²
Select/SingleMetricReducedSeries-12                     10.93k ± ∞ ¹                             10.93k ± ∞ ¹       ~ (p=1.000 n=5) ²
Select/SingleMetricOneSeries-12                         10.90k ± ∞ ¹                             10.90k ± ∞ ¹       ~ (p=1.000 n=5) ²
Select/SingleMetricSparseSeries-12                      18.00k ± ∞ ¹                             18.00k ± ∞ ¹       ~ (p=1.000 n=5) ²
Select/NonExistentSeries-12                             10.76k ± ∞ ¹                             10.76k ± ∞ ¹       ~ (p=1.000 n=5) ²
Select/MultipleMetricsRange-12                          72.41k ± ∞ ¹                             72.41k ± ∞ ¹       ~ (p=1.000 n=5) ²
Select/MultipleMetricsSparse-12                         47.21k ± ∞ ¹                             47.21k ± ∞ ¹       ~ (p=1.000 n=5) ²
Select/NegativeRegexSingleMetric-12                     25.08k ± ∞ ¹                             25.08k ± ∞ ¹       ~ (p=1.000 n=5) ²
Select/NegativeRegexMultipleMetrics-12                  81.76k ± ∞ ¹                             81.76k ± ∞ ¹       ~ (p=1.000 n=5) ²
Select/ExpensiveRegexSingleMetric-12                    18.69k ± ∞ ¹                             18.69k ± ∞ ¹       ~ (p=1.000 n=5) ²
Select/ExpensiveRegexMultipleMetrics-12                 62.10k ± ∞ ¹                             62.10k ± ∞ ¹       ~ (p=1.000 n=5) ²
geomean                                                 25.95k                                   25.95k        +0.00%
¹ need >= 6 samples for confidence interval at level 0.95
² all samples are equal

                                        │ with-filesystem-bucket.out │ with-custom-filesystem-bucket-and-less-open-and-stat-calls.out │
                                        │         series/op          │               series/op                 vs base                │
Select/SingleMetricAllSeries-12                         300.0k ± ∞ ¹                             300.0k ± ∞ ¹       ~ (p=1.000 n=5) ²
Select/SingleMetricReducedSeries-12                     3.000k ± ∞ ¹                             3.000k ± ∞ ¹       ~ (p=1.000 n=5) ²
Select/SingleMetricOneSeries-12                          1.000 ± ∞ ¹                              1.000 ± ∞ ¹       ~ (p=1.000 n=5) ²
Select/SingleMetricSparseSeries-12                      5.000k ± ∞ ¹                             5.000k ± ∞ ¹       ~ (p=1.000 n=5) ²
Select/NonExistentSeries-12                              0.000 ± ∞ ¹                              0.000 ± ∞ ¹       ~ (p=1.000 n=5) ²
Select/MultipleMetricsRange-12                          1.200M ± ∞ ¹                             1.200M ± ∞ ¹       ~ (p=1.000 n=5) ²
Select/MultipleMetricsSparse-12                         300.0k ± ∞ ¹                             300.0k ± ∞ ¹       ~ (p=1.000 n=5) ²
Select/NegativeRegexSingleMetric-12                     234.0k ± ∞ ¹                             234.0k ± ∞ ¹       ~ (p=1.000 n=5) ²
Select/NegativeRegexMultipleMetrics-12                  702.0k ± ∞ ¹                             702.0k ± ∞ ¹       ~ (p=1.000 n=5) ²
Select/ExpensiveRegexSingleMetric-12                    6.000k ± ∞ ¹                             6.000k ± ∞ ¹       ~ (p=1.000 n=5) ²
Select/ExpensiveRegexMultipleMetrics-12                  0.000 ± ∞ ¹                              0.000 ± ∞ ¹       ~ (p=1.000 n=5) ²
geomean                                                            ³                                           +0.00%               ³
¹ need >= 6 samples for confidence interval at level 0.95
² all samples are equal
³ summaries must be >0 to compute geomean

                                        │ with-filesystem-bucket.out │ with-custom-filesystem-bucket-and-less-open-and-stat-calls.out │
                                        │            B/op            │                   B/op                    vs base              │
Select/SingleMetricAllSeries-12                        787.3Mi ± ∞ ¹                              777.0Mi ± ∞ ¹  -1.30% (p=0.008 n=5)
Select/SingleMetricReducedSeries-12                    77.49Mi ± ∞ ¹                              71.65Mi ± ∞ ¹  -7.54% (p=0.008 n=5)
Select/SingleMetricOneSeries-12                        72.79Mi ± ∞ ¹                              66.96Mi ± ∞ ¹  -8.01% (p=0.008 n=5)
Select/SingleMetricSparseSeries-12                     140.8Mi ± ∞ ¹                              131.1Mi ± ∞ ¹  -6.83% (p=0.008 n=5)
Select/NonExistentSeries-12                            69.80Mi ± ∞ ¹                              64.05Mi ± ∞ ¹  -8.24% (p=0.008 n=5)
Select/MultipleMetricsRange-12                         3.146Gi ± ∞ ¹                              3.109Gi ± ∞ ¹  -1.20% (p=0.008 n=5)
Select/MultipleMetricsSparse-12                        1.058Gi ± ∞ ¹                              1.033Gi ± ∞ ¹  -2.33% (p=0.008 n=5)
Select/NegativeRegexSingleMetric-12                    729.6Mi ± ∞ ¹                              716.2Mi ± ∞ ¹  -1.84% (p=0.008 n=5)
Select/NegativeRegexMultipleMetrics-12                 2.213Gi ± ∞ ¹                              2.170Gi ± ∞ ¹  -1.93% (p=0.008 n=5)
Select/ExpensiveRegexSingleMetric-12                   202.7Mi ± ∞ ¹                              192.6Mi ± ∞ ¹  -4.94% (p=0.008 n=5)
Select/ExpensiveRegexMultipleMetrics-12                573.1Mi ± ∞ ¹                              539.9Mi ± ∞ ¹  -5.79% (p=0.008 n=5)
geomean                                                387.1Mi                                    369.3Mi        -4.58%
¹ need >= 6 samples for confidence interval at level 0.95

                                        │ with-filesystem-bucket.out │ with-custom-filesystem-bucket-and-less-open-and-stat-calls.out │
                                        │         allocs/op          │                allocs/op                 vs base               │
Select/SingleMetricAllSeries-12                         9.960M ± ∞ ¹                              9.845M ± ∞ ¹   -1.15% (p=0.008 n=5)
Select/SingleMetricReducedSeries-12                     355.1k ± ∞ ¹                              289.6k ± ∞ ¹  -18.46% (p=0.008 n=5)
Select/SingleMetricOneSeries-12                         331.7k ± ∞ ¹                              266.2k ± ∞ ¹  -19.73% (p=0.008 n=5)
Select/SingleMetricSparseSeries-12                      755.9k ± ∞ ¹                              647.9k ± ∞ ¹  -14.29% (p=0.008 n=5)
Select/NonExistentSeries-12                             256.1k ± ∞ ¹                              191.6k ± ∞ ¹  -25.21% (p=0.008 n=5)
Select/MultipleMetricsRange-12                          40.14M ± ∞ ¹                              39.71M ± ∞ ¹   -1.08% (p=0.008 n=5)
Select/MultipleMetricsSparse-12                         11.10M ± ∞ ¹                              10.82M ± ∞ ¹   -2.55% (p=0.008 n=5)
Select/NegativeRegexSingleMetric-12                     8.504M ± ∞ ¹                              8.353M ± ∞ ¹   -1.77% (p=0.008 n=5)
Select/NegativeRegexMultipleMetrics-12                  24.99M ± ∞ ¹                              24.50M ± ∞ ¹   -1.96% (p=0.008 n=5)
Select/ExpensiveRegexSingleMetric-12                   1027.8k ± ∞ ¹                              915.7k ± ∞ ¹  -10.92% (p=0.008 n=5)
Select/ExpensiveRegexMultipleMetrics-12                 2.168M ± ∞ ¹                              1.796M ± ∞ ¹  -17.19% (p=0.008 n=5)
geomean                                                 2.664M                                    2.376M        -10.81%
¹ need >= 6 samples for confidence interval at level 0.95
```
</details>

Summary:
* Geomean shows 53.71% improvement so about 2x faster.
* 10.81% fewer allocations and 4.6% less memory usage.
* The benchmark cases that benefited the more were:
  * SingleMetricReducedSeries: -71.09% (85ms → 24.6ms)
  * SingleMetricOneSeries: -71.40% (78.5ms → 22.4ms)
  * NonExistentSeries: -71.87% (77.4ms → 21.8ms)
  * ExpensiveRegexMultipleMetrics: -70.17% (488ms → 146ms)

Note: I also tried the InMemBucket implementation but it did deadlock and I figured maybe filesystem with safe ReadAt would be easier to achieve these performance improvements. Also closer to what it would look like in our systems I think.


