### PR TITLE
queryable: Extract queryable from search

### DIFF
--- a/queryable/filesystem_test.go
+++ b/queryable/filesystem_test.go
@@ -14,7 +14,7 @@
 // Provenance-includes-license: Apache-2.0
 // Provenance-includes-copyright: The Thanos Authors.
 
-package search
+package queryable
 
 import (
 	"bytes"

--- a/queryable/parquet_queryable.go
+++ b/queryable/parquet_queryable.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package search
+package queryable
 
 import (
 	"context"
@@ -26,6 +26,7 @@ import (
 
 	"github.com/prometheus-community/parquet-common/convert"
 	"github.com/prometheus-community/parquet-common/schema"
+	"github.com/prometheus-community/parquet-common/search"
 	"github.com/prometheus-community/parquet-common/storage"
 	"github.com/prometheus-community/parquet-common/util"
 )
@@ -211,7 +212,7 @@ func (p parquetQuerier) queryableShards(ctx context.Context, mint, maxt int64) (
 
 type queryableShard struct {
 	shard       storage.ParquetShard
-	m           *Materializer
+	m           *search.Materializer
 	concurrency int
 }
 
@@ -220,7 +221,7 @@ func newQueryableShard(opts *queryableOpts, block storage.ParquetShard, d *schem
 	if err != nil {
 		return nil, err
 	}
-	m, err := NewMaterializer(s, d, block, opts.concurrency, opts.pagePartitioningMaxGapSize)
+	m, err := search.NewMaterializer(s, d, block, opts.concurrency, opts.pagePartitioningMaxGapSize)
 	if err != nil {
 		return nil, err
 	}
@@ -241,15 +242,15 @@ func (b queryableShard) Query(ctx context.Context, sorted bool, mint, maxt int64
 
 	for i, group := range b.shard.LabelsFile().RowGroups() {
 		errGroup.Go(func() error {
-			cs, err := MatchersToConstraint(matchers...)
+			cs, err := search.MatchersToConstraint(matchers...)
 			if err != nil {
 				return err
 			}
-			err = Initialize(b.shard.LabelsFile(), cs...)
+			err = search.Initialize(b.shard.LabelsFile(), cs...)
 			if err != nil {
 				return err
 			}
-			rr, err := Filter(ctx, group, cs...)
+			rr, err := search.Filter(ctx, group, cs...)
 			if err != nil {
 				return err
 			}
@@ -291,15 +292,15 @@ func (b queryableShard) LabelNames(ctx context.Context, limit int64, matchers []
 
 	for i, group := range b.shard.LabelsFile().RowGroups() {
 		errGroup.Go(func() error {
-			cs, err := MatchersToConstraint(matchers...)
+			cs, err := search.MatchersToConstraint(matchers...)
 			if err != nil {
 				return err
 			}
-			err = Initialize(b.shard.LabelsFile(), cs...)
+			err = search.Initialize(b.shard.LabelsFile(), cs...)
 			if err != nil {
 				return err
 			}
-			rr, err := Filter(ctx, group, cs...)
+			rr, err := search.Filter(ctx, group, cs...)
 			if err != nil {
 				return err
 			}
@@ -331,15 +332,15 @@ func (b queryableShard) LabelValues(ctx context.Context, name string, limit int6
 
 	for i, group := range b.shard.LabelsFile().RowGroups() {
 		errGroup.Go(func() error {
-			cs, err := MatchersToConstraint(matchers...)
+			cs, err := search.MatchersToConstraint(matchers...)
 			if err != nil {
 				return err
 			}
-			err = Initialize(b.shard.LabelsFile(), cs...)
+			err = search.Initialize(b.shard.LabelsFile(), cs...)
 			if err != nil {
 				return err
 			}
-			rr, err := Filter(ctx, group, cs...)
+			rr, err := search.Filter(ctx, group, cs...)
 			if err != nil {
 				return err
 			}

--- a/search/materialize_test.go
+++ b/search/materialize_test.go
@@ -27,6 +27,8 @@ import (
 	"github.com/prometheus/prometheus/util/teststorage"
 	"github.com/stretchr/testify/require"
 
+	"github.com/thanos-io/objstore/providers/filesystem"
+
 	"github.com/prometheus-community/parquet-common/convert"
 	"github.com/prometheus-community/parquet-common/schema"
 	"github.com/prometheus-community/parquet-common/storage"
@@ -38,7 +40,7 @@ func TestMaterializeE2E(t *testing.T) {
 	ctx := context.Background()
 	t.Cleanup(func() { _ = st.Close() })
 
-	bkt, err := newBucket(t.TempDir())
+	bkt, err := filesystem.NewBucket(t.TempDir())
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = bkt.Close() })
 
@@ -57,16 +59,6 @@ func TestMaterializeE2E(t *testing.T) {
 			require.Equal(t, series.Labels().Get("unique"), "unique_0")
 			require.Contains(t, data.SeriesHash, series.Labels().Hash())
 		}
-
-		matchers := []*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, "unique", "unique_0")}
-		sFound := queryWithQueryable(t, data.MinTime, data.MaxTime, shard, nil, matchers...)
-		totalFound := 0
-		for _, series := range sFound {
-			require.Equal(t, series.Labels().Get("unique"), "unique_0")
-			require.Contains(t, data.SeriesHash, series.Labels().Hash())
-			totalFound++
-		}
-		require.Equal(t, cfg.TotalMetricNames, totalFound)
 	})
 
 	t.Run("QueryByMetricName", func(t *testing.T) {
@@ -91,16 +83,6 @@ func TestMaterializeE2E(t *testing.T) {
 				}
 				require.Equal(t, totalSamples, cfg.NumberOfSamples)
 			}
-
-			matchers := []*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, labels.MetricName, name)}
-			sFound := queryWithQueryable(t, data.MinTime, data.MaxTime, shard, nil, matchers...)
-			totalFound := 0
-			for _, series := range sFound {
-				totalFound++
-				require.Equal(t, series.Labels().Get(labels.MetricName), name)
-				require.Contains(t, data.SeriesHash, series.Labels().Hash())
-			}
-			require.Equal(t, cfg.MetricsPerMetricName, totalFound)
 		}
 	})
 
@@ -149,7 +131,7 @@ func TestMaterializeE2E(t *testing.T) {
 	})
 }
 
-func convertToParquet(t *testing.T, ctx context.Context, bkt *bucket, data util.TestData, h convert.Convertible, opts ...storage.ShardOption) storage.ParquetShard {
+func convertToParquet(t *testing.T, ctx context.Context, bkt *filesystem.Bucket, data util.TestData, h convert.Convertible, opts ...storage.ShardOption) storage.ParquetShard {
 	colDuration := time.Hour
 	shards, err := convert.ConvertTSDBBlock(
 		ctx,


### PR DESCRIPTION
I was discussing with @MichaHoffmann that its starting to feel that the library is doing too much particularly around the Queryable part, specially since Thanos users probably cant use it and need their own due to some specific requirements around Thanos queryable.

Eventually if this effort gets upstream acceptance I can see how the queryable we have here could actually live in Prometheus in a parquet package for example and Thanos would have its own as well. Maybe this also applies to other similar downstream projects like Cortex, Mimir etcetera.

In this PR what I'm trying to do is to make that split now as a temporary step but I think it helps reflect the direction we are taking.

Thoughts?