### PR TITLE
Implement optimistic reader on the search phase

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea/
+vendor/

--- a/queryable/parquet_queryable.go
+++ b/queryable/parquet_queryable.go
@@ -237,7 +237,7 @@ func (b queryableShard) Query(ctx context.Context, sorted bool, mint, maxt int64
 			if err != nil {
 				return err
 			}
-			err = search.Initialize(b.shard, cs...)
+			err = search.Initialize(b.shard.LabelsFile(), cs...)
 			if err != nil {
 				return err
 			}
@@ -287,7 +287,7 @@ func (b queryableShard) LabelNames(ctx context.Context, limit int64, matchers []
 			if err != nil {
 				return err
 			}
-			err = search.Initialize(b.shard, cs...)
+			err = search.Initialize(b.shard.LabelsFile(), cs...)
 			if err != nil {
 				return err
 			}
@@ -327,7 +327,7 @@ func (b queryableShard) LabelValues(ctx context.Context, name string, limit int6
 			if err != nil {
 				return err
 			}
-			err = search.Initialize(b.shard, cs...)
+			err = search.Initialize(b.shard.LabelsFile(), cs...)
 			if err != nil {
 				return err
 			}

--- a/queryable/parquet_queryable.go
+++ b/queryable/parquet_queryable.go
@@ -34,13 +34,11 @@ import (
 type ShardsFinderFunction func(ctx context.Context, mint, maxt int64) ([]storage.ParquetShard, error)
 
 type queryableOpts struct {
-	concurrency                int
-	pagePartitioningMaxGapSize int
+	concurrency int
 }
 
 var DefaultQueryableOpts = queryableOpts{
-	concurrency:                runtime.GOMAXPROCS(0),
-	pagePartitioningMaxGapSize: 10 * 1024,
+	concurrency: runtime.GOMAXPROCS(0),
 }
 
 type QueryableOpts func(*queryableOpts)
@@ -49,13 +47,6 @@ type QueryableOpts func(*queryableOpts)
 func WithConcurrency(concurrency int) QueryableOpts {
 	return func(opts *queryableOpts) {
 		opts.concurrency = concurrency
-	}
-}
-
-// WithPageMaxGapSize set the max gap size between pages that should be downloaded together in a single read call
-func WithPageMaxGapSize(pagePartitioningMaxGapSize int) QueryableOpts {
-	return func(opts *queryableOpts) {
-		opts.pagePartitioningMaxGapSize = pagePartitioningMaxGapSize
 	}
 }
 
@@ -221,7 +212,7 @@ func newQueryableShard(opts *queryableOpts, block storage.ParquetShard, d *schem
 	if err != nil {
 		return nil, err
 	}
-	m, err := search.NewMaterializer(s, d, block, opts.concurrency, opts.pagePartitioningMaxGapSize)
+	m, err := search.NewMaterializer(s, d, block, opts.concurrency)
 	if err != nil {
 		return nil, err
 	}
@@ -246,11 +237,11 @@ func (b queryableShard) Query(ctx context.Context, sorted bool, mint, maxt int64
 			if err != nil {
 				return err
 			}
-			err = search.Initialize(b.shard.LabelsFile(), cs...)
+			err = search.Initialize(b.shard, cs...)
 			if err != nil {
 				return err
 			}
-			rr, err := search.Filter(ctx, b.shard.LabelsFile(), rgi, cs...)
+			rr, err := search.Filter(ctx, b.shard, rgi, cs...)
 			if err != nil {
 				return err
 			}
@@ -296,11 +287,11 @@ func (b queryableShard) LabelNames(ctx context.Context, limit int64, matchers []
 			if err != nil {
 				return err
 			}
-			err = search.Initialize(b.shard.LabelsFile(), cs...)
+			err = search.Initialize(b.shard, cs...)
 			if err != nil {
 				return err
 			}
-			rr, err := search.Filter(ctx, b.shard.LabelsFile(), rgi, cs...)
+			rr, err := search.Filter(ctx, b.shard, rgi, cs...)
 			if err != nil {
 				return err
 			}
@@ -336,11 +327,11 @@ func (b queryableShard) LabelValues(ctx context.Context, name string, limit int6
 			if err != nil {
 				return err
 			}
-			err = search.Initialize(b.shard.LabelsFile(), cs...)
+			err = search.Initialize(b.shard, cs...)
 			if err != nil {
 				return err
 			}
-			rr, err := search.Filter(ctx, b.shard.LabelsFile(), rgi, cs...)
+			rr, err := search.Filter(ctx, b.shard, rgi, cs...)
 			if err != nil {
 				return err
 			}

--- a/queryable/parquet_queryable.go
+++ b/queryable/parquet_queryable.go
@@ -321,7 +321,7 @@ func (b queryableShard) LabelValues(ctx context.Context, name string, limit int6
 
 	results := make([][]string, len(b.shard.LabelsFile().RowGroups()))
 
-	for rgi, _ := range b.shard.LabelsFile().RowGroups() {
+	for rgi := range b.shard.LabelsFile().RowGroups() {
 		errGroup.Go(func() error {
 			cs, err := search.MatchersToConstraint(matchers...)
 			if err != nil {

--- a/queryable/parquet_queryable_test.go
+++ b/queryable/parquet_queryable_test.go
@@ -171,6 +171,7 @@ func TestQueryable(t *testing.T) {
 				storage.WithFileOptions(
 					parquet.SkipBloomFilters(true),
 				),
+				storage.WithOptimisticReader(true),
 			},
 		},
 	}
@@ -544,7 +545,7 @@ func convertToParquet(t *testing.T, ctx context.Context, bkt *bucket, data util.
 
 	bucketOpener := storage.NewParquetBucketOpener(bkt)
 	shard, err := storage.NewParquetShardOpener(
-		ctx, "shard", bucketOpener, bucketOpener, 0,
+		ctx, "shard", bucketOpener, bucketOpener, 0, opts...,
 	)
 	if err != nil {
 		t.Fatalf("error opening parquet shard: %v", err)

--- a/queryable/parquet_queryable_test.go
+++ b/queryable/parquet_queryable_test.go
@@ -161,17 +161,17 @@ func TestQueryable(t *testing.T) {
 	require.NoError(t, err)
 
 	testCases := map[string]struct {
-		ops []storage.ShardOption
+		ops []storage.FileOption
 	}{
 		"default": {
-			ops: []storage.ShardOption{},
+			ops: []storage.FileOption{},
 		},
 		"skipBloomFilters": {
-			ops: []storage.ShardOption{
+			ops: []storage.FileOption{
 				storage.WithFileOptions(
 					parquet.SkipBloomFilters(true),
+					parquet.OptimisticRead(true),
 				),
-				storage.WithOptimisticReader(true),
 			},
 		},
 	}
@@ -523,7 +523,7 @@ func BenchmarkSelect(b *testing.B) {
 	}
 }
 
-func convertToParquet(t *testing.T, ctx context.Context, bkt *bucket, data util.TestData, h convert.Convertible, opts ...storage.ShardOption) storage.ParquetShard {
+func convertToParquet(t *testing.T, ctx context.Context, bkt *bucket, data util.TestData, h convert.Convertible, opts ...storage.FileOption) storage.ParquetShard {
 	colDuration := time.Hour
 	shards, err := convert.ConvertTSDBBlock(
 		ctx,
@@ -554,7 +554,7 @@ func convertToParquet(t *testing.T, ctx context.Context, bkt *bucket, data util.
 	return shard
 }
 
-func convertToParquetForBenchWithCountingBucket(tb testing.TB, ctx context.Context, bkt *bucket, cbkt *countingBucket, data util.TestData, h convert.Convertible, opts ...storage.ShardOption) storage.ParquetShard {
+func convertToParquetForBenchWithCountingBucket(tb testing.TB, ctx context.Context, bkt *bucket, cbkt *countingBucket, data util.TestData, h convert.Convertible, opts ...storage.FileOption) storage.ParquetShard {
 	colDuration := time.Hour
 	shards, err := convert.ConvertTSDBBlock(
 		ctx,

--- a/search/constraint.go
+++ b/search/constraint.go
@@ -19,10 +19,12 @@ import (
 	"fmt"
 	"slices"
 	"sort"
+	"sync"
 
 	"github.com/parquet-go/parquet-go"
 	"github.com/pkg/errors"
 	"github.com/prometheus/prometheus/model/labels"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/prometheus-community/parquet-common/schema"
 	"github.com/prometheus-community/parquet-common/storage"
@@ -33,7 +35,7 @@ type Constraint interface {
 	fmt.Stringer
 
 	// filter returns a set of non-overlapping increasing row indexes that may satisfy the constraint.
-	filter(ctx context.Context, rg parquet.RowGroup, primary bool, rr []RowRange) ([]RowRange, error)
+	filter(ctx context.Context, rgIdx int, primary bool, rr []RowRange) ([]RowRange, error)
 	// init initializes the constraint with respect to the file schema and projections.
 	init(f *storage.ParquetFile) error
 	// path is the path for the column that is constrained
@@ -76,7 +78,9 @@ func Initialize(f *storage.ParquetFile, cs ...Constraint) error {
 	return nil
 }
 
-func Filter(ctx context.Context, rg parquet.RowGroup, cs ...Constraint) ([]RowRange, error) {
+func Filter(ctx context.Context, f *storage.ParquetFile, rgIdx int, cs ...Constraint) ([]RowRange, error) {
+
+	rg := f.RowGroups()[rgIdx]
 	// Constraints for sorting columns are cheaper to evaluate, so we sort them first.
 	sc := rg.SortingColumns()
 
@@ -96,12 +100,25 @@ func Filter(ctx context.Context, rg parquet.RowGroup, cs ...Constraint) ([]RowRa
 	rr := []RowRange{{from: int64(0), count: rg.NumRows()}}
 	for i := range cs {
 		isPrimary := len(sc) > 0 && cs[i].path() == sc[0].Path()[0]
-		rr, err = cs[i].filter(ctx, rg, isPrimary, rr)
+		rr, err = cs[i].filter(ctx, rgIdx, isPrimary, rr)
 		if err != nil {
 			return nil, fmt.Errorf("unable to filter with constraint %d: %w", i, err)
 		}
 	}
 	return rr, nil
+}
+
+type pageToRead struct {
+	// for data pages
+	pfrom int64
+	pto   int64
+
+	// -1 for dictionary page
+	idx int
+
+	// for data and dictionary pages
+	off int
+	csz int
 }
 
 // symbolTable is a helper that can decode the i-th value of a page.
@@ -168,11 +185,13 @@ func Equal(path string, value parquet.Value) Constraint {
 	return &equalConstraint{pth: path, val: value}
 }
 
-func (ec *equalConstraint) filter(ctx context.Context, rg parquet.RowGroup, primary bool, rr []RowRange) ([]RowRange, error) {
+func (ec *equalConstraint) filter(ctx context.Context, rgIdx int, primary bool, rr []RowRange) ([]RowRange, error) {
 	if len(rr) == 0 {
 		return nil, nil
 	}
 	from, to := rr[0].from, rr[len(rr)-1].from+rr[len(rr)-1].count
+
+	rg := ec.f.RowGroups()[rgIdx]
 
 	col, ok := rg.Schema().Lookup(ec.path())
 	if !ok {
@@ -206,10 +225,15 @@ func (ec *equalConstraint) filter(ctx context.Context, rg parquet.RowGroup, prim
 		return nil, fmt.Errorf("unable to read column index: %w", err)
 	}
 	var (
-		symbols = new(symbolTable)
-		res     = make([]RowRange, 0)
+		res = make([]RowRange, 0)
 	)
+
+	dictOff, dictSz := ec.f.DictionaryPageBounds(rgIdx, col.ColumnIndex)
+	readPgs := []pageToRead{pageToRead{idx: -1, off: int(dictOff), csz: int(dictSz)}}
+
 	for i := 0; i < cidx.NumPages(); i++ {
+		poff, pcsz := uint64(oidx.Offset(i)), oidx.CompressedPageSize(i)
+
 		// If page does not intersect from, to; we can immediately discard it
 		pfrom := oidx.FirstRowIndex(i)
 		pcount := rg.NumRows() - pfrom
@@ -246,49 +270,99 @@ func (ec *equalConstraint) filter(ctx context.Context, rg parquet.RowGroup, prim
 			continue
 		}
 		// We cannot discard the page through statistics but we might need to read it to see if it has the value
-		if err := pgs.SeekToRow(pfrom); err != nil {
-			return nil, fmt.Errorf("unable to seek to row: %w", err)
-		}
-		pg, err := pgs.ReadPage()
-		if err != nil {
-			return nil, fmt.Errorf("unable to read page: %w", err)
-		}
+		readPgs = append(readPgs, pageToRead{pfrom: pfrom, pto: pto, idx: i, off: int(poff), csz: int(pcsz)})
+	}
 
-		symbols.Reset(pg)
+	if len(readPgs) == 1 {
+		return nil, nil
+	}
 
-		// The page has the value, we need to find the matching row ranges
-		n := int(pg.NumRows())
-		bl := int(max(pfrom, from) - pfrom)
-		br := n - int(pto-min(pto, to))
-		var l, r int
-		switch {
-		case cidx.IsAscending() && primary:
-			l = sort.Search(n, func(i int) bool { return ec.comp(ec.val, symbols.Get(i)) <= 0 })
-			r = sort.Search(n, func(i int) bool { return ec.comp(ec.val, symbols.Get(i)) < 0 })
+	partitioner := util.NewGapBasedPartitioner(10 * 1024)
+	parts := partitioner.Partition(len(readPgs), func(i int) (int, int) {
+		return readPgs[i].off, readPgs[i].off + readPgs[i].csz
+	})
 
-			if lv, rv := max(bl, l), min(br, r); rv > lv {
-				res = append(res, RowRange{pfrom + int64(lv), int64(rv - lv)})
-			}
-		default:
-			off, count := bl, 0
-			for j := bl; j < br; j++ {
-				if !ec.matches(symbols.Get(j)) {
+	var mu sync.Mutex
+	g, ctx := errgroup.WithContext(ctx)
+	for _, p := range parts {
+		g.Go(func() error {
+			partFrom, partTo := p.ElemRng[0], p.ElemRng[1]-1
+
+			minOffset := readPgs[partFrom].off
+			maxOffset := readPgs[partTo].off + readPgs[partTo].csz
+
+			bufRdrAt := storage.NewOptimisticReaderAt(ec.f.ReadAtWithContextCloser.WithContext(ctx), int64(minOffset), int64(maxOffset))
+
+			pgs := cc.(*parquet.FileColumnChunk).PagesFrom(bufRdrAt)
+			defer func() { _ = pgs.Close() }()
+
+			symbols := new(symbolTable)
+			for _, p := range readPgs[partFrom : partTo+1] {
+				// skip faked dictionary page again
+				if p.idx == -1 {
+					continue
+				}
+
+				pfrom := p.pfrom
+				pto := p.pto
+
+				if err := pgs.SeekToRow(pfrom); err != nil {
+					return fmt.Errorf("unable to seek to row: %w", err)
+				}
+				pg, err := pgs.ReadPage()
+				if err != nil {
+					return fmt.Errorf("unable to read page: %w", err)
+				}
+
+				symbols.Reset(pg)
+
+				// The page has the value, we need to find the matching row ranges
+				n := int(pg.NumRows())
+				bl := int(max(pfrom, from) - pfrom)
+				br := n - int(pto-min(pto, to))
+				var l, r int
+				switch {
+				case cidx.IsAscending() && primary:
+					l = sort.Search(n, func(i int) bool { return ec.comp(ec.val, symbols.Get(i)) <= 0 })
+					r = sort.Search(n, func(i int) bool { return ec.comp(ec.val, symbols.Get(i)) < 0 })
+
+					if lv, rv := max(bl, l), min(br, r); rv > lv {
+						mu.Lock()
+						res = append(res, RowRange{pfrom + int64(lv), int64(rv - lv)})
+						mu.Unlock()
+					}
+				default:
+					off, count := bl, 0
+					for j := bl; j < br; j++ {
+						if !ec.matches(symbols.Get(j)) {
+							if count != 0 {
+								mu.Lock()
+								res = append(res, RowRange{pfrom + int64(off), int64(count)})
+								mu.Unlock()
+							}
+							off, count = j, 0
+						} else {
+							if count == 0 {
+								off = j
+							}
+							count++
+						}
+					}
 					if count != 0 {
+						mu.Lock()
 						res = append(res, RowRange{pfrom + int64(off), int64(count)})
+						mu.Unlock()
 					}
-					off, count = j, 0
-				} else {
-					if count == 0 {
-						off = j
-					}
-					count++
 				}
 			}
-			if count != 0 {
-				res = append(res, RowRange{pfrom + int64(off), int64(count)})
-			}
-		}
+
+			return nil
+		})
 	}
+	if err := g.Wait(); err != nil {
+		return nil, fmt.Errorf("unable to scan pages: %w", err)
+	}
+
 	if len(res) == 0 {
 		return nil, nil
 	}
@@ -351,11 +425,13 @@ func (rc *regexConstraint) String() string {
 	return fmt.Sprintf("regex(%v,%v)", rc.pth, rc.r.GetRegexString())
 }
 
-func (rc *regexConstraint) filter(ctx context.Context, rg parquet.RowGroup, primary bool, rr []RowRange) ([]RowRange, error) {
+func (rc *regexConstraint) filter(ctx context.Context, rgIdx int, primary bool, rr []RowRange) ([]RowRange, error) {
 	if len(rr) == 0 {
 		return nil, nil
 	}
 	from, to := rr[0].from, rr[len(rr)-1].from+rr[len(rr)-1].count
+
+	rg := rc.f.RowGroups()[rgIdx]
 
 	col, ok := rg.Schema().Lookup(rc.path())
 	if !ok {
@@ -487,8 +563,8 @@ func (nc *notConstraint) String() string {
 	return fmt.Sprintf("not(%v)", nc.c.String())
 }
 
-func (nc *notConstraint) filter(ctx context.Context, rg parquet.RowGroup, primary bool, rr []RowRange) ([]RowRange, error) {
-	base, err := nc.c.filter(ctx, rg, primary, rr)
+func (nc *notConstraint) filter(ctx context.Context, rgIdx int, primary bool, rr []RowRange) ([]RowRange, error) {
+	base, err := nc.c.filter(ctx, rgIdx, primary, rr)
 	if err != nil {
 		return nil, fmt.Errorf("unable to compute child constraint: %w", err)
 	}

--- a/search/constraint.go
+++ b/search/constraint.go
@@ -77,7 +77,6 @@ func Initialize(s storage.ParquetShard, cs ...Constraint) error {
 }
 
 func Filter(ctx context.Context, s storage.ParquetShard, rgIdx int, cs ...Constraint) ([]RowRange, error) {
-
 	rg := s.LabelsFile().RowGroups()[rgIdx]
 	// Constraints for sorting columns are cheaper to evaluate, so we sort them first.
 	sc := rg.SortingColumns()
@@ -215,9 +214,7 @@ func (ec *equalConstraint) filter(ctx context.Context, rgIdx int, primary bool, 
 	if err != nil {
 		return nil, fmt.Errorf("unable to read column index: %w", err)
 	}
-	var (
-		res = make([]RowRange, 0)
-	)
+	res := make([]RowRange, 0)
 
 	readPgs := make([]pageToRead, 0, 10)
 
@@ -279,7 +276,7 @@ func (ec *equalConstraint) filter(ctx context.Context, rgIdx int, primary bool, 
 		minOffset = dictOff
 	}
 
-	bufRdrAt := ec.s.LabelsFile().ReadAtWithContextCloser.WithContext(ctx)
+	bufRdrAt := ec.s.LabelsFile().WithContext(ctx)
 
 	if ec.s.Opts().OptimisticReader {
 		bufRdrAt = storage.NewOptimisticReaderAt(bufRdrAt, int64(minOffset), int64(maxOffset))

--- a/search/constraint.go
+++ b/search/constraint.go
@@ -229,7 +229,7 @@ func (ec *equalConstraint) filter(ctx context.Context, rgIdx int, primary bool, 
 	)
 
 	dictOff, dictSz := ec.f.DictionaryPageBounds(rgIdx, col.ColumnIndex)
-	readPgs := []pageToRead{pageToRead{idx: -1, off: int(dictOff), csz: int(dictSz)}}
+	readPgs := []pageToRead{{idx: -1, off: int(dictOff), csz: int(dictSz)}}
 
 	for i := 0; i < cidx.NumPages(); i++ {
 		poff, pcsz := uint64(oidx.Offset(i)), oidx.CompressedPageSize(i)

--- a/search/constraint.go
+++ b/search/constraint.go
@@ -364,7 +364,7 @@ func (ec *equalConstraint) matches(v parquet.Value) bool {
 }
 
 func (ec *equalConstraint) skipByBloomfilter(cc parquet.ColumnChunk) (bool, error) {
-	if !ec.s.LabelsFile().BloomFiltersLoaded {
+	if ec.s.LabelsFile().Cfg.SkipBloomFilters {
 		return false, nil
 	}
 

--- a/search/constraint_test.go
+++ b/search/constraint_test.go
@@ -123,8 +123,8 @@ func BenchmarkConstraints(b *testing.B) {
 				if err := Initialize(sfile, tt.c...); err != nil {
 					b.Fatal(err)
 				}
-				for _, rg := range sfile.RowGroups() {
-					rr, err := Filter(context.Background(), rg, tt.c...)
+				for i := range sfile.RowGroups() {
+					rr, err := Filter(context.Background(), sfile, i, tt.c...)
 					if err != nil {
 						b.Fatal(err)
 					}
@@ -159,10 +159,10 @@ func TestContextCancelled(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		for _, rg := range sfile.RowGroups() {
+		for i := range sfile.RowGroups() {
 			ctx, cancel := context.WithCancel(context.Background())
 			cancel()
-			_, err := Filter(ctx, rg, c)
+			_, err := Filter(ctx, sfile, i, c)
 			require.ErrorContains(t, err, "context canceled")
 		}
 	}
@@ -476,8 +476,8 @@ func TestFilter(t *testing.T) {
 					if err := Initialize(sfile, expectation.constraints...); err != nil {
 						t.Fatal(err)
 					}
-					for _, rg := range sfile.RowGroups() {
-						rr, err := Filter(context.Background(), rg, expectation.constraints...)
+					for i := range sfile.RowGroups() {
+						rr, err := Filter(context.Background(), sfile, i, expectation.constraints...)
 						if err != nil {
 							t.Fatal(err)
 						}

--- a/search/constraint_test.go
+++ b/search/constraint_test.go
@@ -129,7 +129,7 @@ func BenchmarkConstraints(b *testing.B) {
 			b.ResetTimer()
 			b.ReportAllocs()
 			for n := 0; n < b.N; n++ {
-				if err := Initialize(shard, tt.c...); err != nil {
+				if err := Initialize(shard.LabelsFile(), tt.c...); err != nil {
 					b.Fatal(err)
 				}
 				for i := range shard.LabelsFile().RowGroups() {
@@ -164,7 +164,7 @@ func TestContextCancelled(t *testing.T) {
 		Regex("A", mustNewFastRegexMatcher(t, rows[len(rows)-1].A)),
 		Not(Equal("A", parquet.ValueOf(rows[len(rows)-1].A))),
 	} {
-		if err := Initialize(shard, c); err != nil {
+		if err := Initialize(shard.LabelsFile(), c); err != nil {
 			t.Fatal(err)
 		}
 
@@ -482,7 +482,7 @@ func TestFilter(t *testing.T) {
 			shard := buildFile(t, tt.rows)
 			for _, expectation := range tt.expectations {
 				t.Run("", func(t *testing.T) {
-					if err := Initialize(shard, expectation.constraints...); err != nil {
+					if err := Initialize(shard.LabelsFile(), expectation.constraints...); err != nil {
 						t.Fatal(err)
 					}
 					for i := range shard.LabelsFile().RowGroups() {

--- a/search/constraint_test.go
+++ b/search/constraint_test.go
@@ -17,6 +17,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"slices"
 	"strconv"
 	"strings"
@@ -30,7 +31,7 @@ import (
 	"github.com/prometheus-community/parquet-common/storage"
 )
 
-func buildFile[T any](t testing.TB, rows []T) *storage.ParquetFile {
+func buildFile[T any](t testing.TB, rows []T) storage.ParquetShard {
 	buf := bytes.NewBuffer(nil)
 	w := parquet.NewGenericWriter[T](buf, parquet.PageBufferSize(10))
 	for _, row := range rows {
@@ -44,13 +45,21 @@ func buildFile[T any](t testing.TB, rows []T) *storage.ParquetFile {
 	bkt, err := filesystem.NewBucket(t.TempDir())
 	require.NoError(t, err)
 	reader := bytes.NewReader(buf.Bytes())
-	require.NoError(t, bkt.Upload(context.Background(), "pipe", reader))
+	require.NoError(t, bkt.Upload(context.Background(), "pipe/0.labels.parquet", reader))
 
-	f, err := storage.OpenFromBucket(context.Background(), bkt, "pipe", storage.WithFileOptions(parquet.ReadBufferSize(1)))
+	// Lets create a mocked chunks file
+	_, err = reader.Seek(0, io.SeekStart)
+	require.NoError(t, err)
+	require.NoError(t, bkt.Upload(context.Background(), "pipe/0.chunks.parquet", reader))
+
+	bucketOpener := storage.NewParquetBucketOpener(bkt)
+	shard, err := storage.NewParquetShardOpener(
+		context.Background(), "pipe", bucketOpener, bucketOpener, 0,
+	)
 	if err != nil {
 		t.Fatal(err)
 	}
-	return f
+	return shard
 }
 
 func mustNewFastRegexMatcher(t testing.TB, s string) *labels.FastRegexMatcher {
@@ -80,7 +89,7 @@ func BenchmarkConstraints(b *testing.B) {
 		}
 	}
 
-	sfile := buildFile(b, rows)
+	shard := buildFile(b, rows)
 
 	tests := []struct {
 		c []Constraint
@@ -120,11 +129,11 @@ func BenchmarkConstraints(b *testing.B) {
 			b.ResetTimer()
 			b.ReportAllocs()
 			for n := 0; n < b.N; n++ {
-				if err := Initialize(sfile, tt.c...); err != nil {
+				if err := Initialize(shard, tt.c...); err != nil {
 					b.Fatal(err)
 				}
-				for i := range sfile.RowGroups() {
-					rr, err := Filter(context.Background(), sfile, i, tt.c...)
+				for i := range shard.LabelsFile().RowGroups() {
+					rr, err := Filter(context.Background(), shard, i, tt.c...)
 					if err != nil {
 						b.Fatal(err)
 					}
@@ -148,21 +157,21 @@ func TestContextCancelled(t *testing.T) {
 		})
 	}
 
-	sfile := buildFile(t, rows)
+	shard := buildFile(t, rows)
 
 	for _, c := range []Constraint{
 		Equal("A", parquet.ValueOf(rows[len(rows)-1].A)),
 		Regex("A", mustNewFastRegexMatcher(t, rows[len(rows)-1].A)),
 		Not(Equal("A", parquet.ValueOf(rows[len(rows)-1].A))),
 	} {
-		if err := Initialize(sfile, c); err != nil {
+		if err := Initialize(shard, c); err != nil {
 			t.Fatal(err)
 		}
 
-		for i := range sfile.RowGroups() {
+		for i := range shard.LabelsFile().RowGroups() {
 			ctx, cancel := context.WithCancel(context.Background())
 			cancel()
-			_, err := Filter(ctx, sfile, i, c)
+			_, err := Filter(ctx, shard, i, c)
 			require.ErrorContains(t, err, "context canceled")
 		}
 	}
@@ -470,14 +479,14 @@ func TestFilter(t *testing.T) {
 			},
 		} {
 
-			sfile := buildFile(t, tt.rows)
+			shard := buildFile(t, tt.rows)
 			for _, expectation := range tt.expectations {
 				t.Run("", func(t *testing.T) {
-					if err := Initialize(sfile, expectation.constraints...); err != nil {
+					if err := Initialize(shard, expectation.constraints...); err != nil {
 						t.Fatal(err)
 					}
-					for i := range sfile.RowGroups() {
-						rr, err := Filter(context.Background(), sfile, i, expectation.constraints...)
+					for i := range shard.LabelsFile().RowGroups() {
+						rr, err := Filter(context.Background(), shard, i, expectation.constraints...)
 						if err != nil {
 							t.Fatal(err)
 						}

--- a/search/materialize.go
+++ b/search/materialize.go
@@ -50,7 +50,6 @@ func NewMaterializer(s *schema.TSDBSchema,
 	d *schema.PrometheusParquetChunksDecoder,
 	block storage.ParquetShard,
 	concurrency int,
-	maxGapPartitioning int,
 ) (*Materializer, error) {
 	colIdx, ok := block.LabelsFile().Schema().Lookup(schema.ColIndexes)
 	if !ok {
@@ -73,7 +72,7 @@ func NewMaterializer(s *schema.TSDBSchema,
 		b:              block,
 		colIdx:         colIdx.ColumnIndex,
 		concurrency:    concurrency,
-		partitioner:    util.NewGapBasedPartitioner(maxGapPartitioning),
+		partitioner:    util.NewGapBasedPartitioner(block.Opts().PagePartitioningMaxGapSize),
 		dataColToIndex: dataColToIndex,
 	}, nil
 }

--- a/search/materialize.go
+++ b/search/materialize.go
@@ -72,7 +72,7 @@ func NewMaterializer(s *schema.TSDBSchema,
 		b:              block,
 		colIdx:         colIdx.ColumnIndex,
 		concurrency:    concurrency,
-		partitioner:    util.NewGapBasedPartitioner(block.Opts().PagePartitioningMaxGapSize),
+		partitioner:    util.NewGapBasedPartitioner(block.ChunksFile().Cfg.PagePartitioningMaxGapSize),
 		dataColToIndex: dataColToIndex,
 	}, nil
 }
@@ -356,7 +356,7 @@ func (m *Materializer) materializeColumn(ctx context.Context, file *storage.Parq
 			maxOffset := uint64(p.off + p.csz)
 
 			// if dictOff == 0, it means that the collum is not dictionary encoded
-			if dictOff > 0 && int(minOffset-(dictOff+dictSz)) < m.b.Opts().PagePartitioningMaxGapSize {
+			if dictOff > 0 && int(minOffset-(dictOff+dictSz)) < file.Cfg.PagePartitioningMaxGapSize {
 				minOffset = dictOff
 			}
 

--- a/search/materialize_test.go
+++ b/search/materialize_test.go
@@ -124,6 +124,7 @@ func TestMaterializeE2E(t *testing.T) {
 		shard, err := storage.NewParquetShardOpener(
 			ctx, "shard", bucketOpener, bucketOpener, 0, storage.WithPageMaxGapSize(-1),
 		)
+		require.NoError(t, err)
 		s, err := shard.TSDBSchema()
 		require.NoError(t, err)
 		d := schema.NewPrometheusParquetChunksDecoder(chunkenc.NewPool())

--- a/search/materialize_test.go
+++ b/search/materialize_test.go
@@ -169,8 +169,8 @@ func query(t *testing.T, mint, maxt int64, shard storage.ParquetShard, constrain
 	require.NoError(t, err)
 
 	found := make([]prom_storage.ChunkSeries, 0, 100)
-	for i, group := range shard.LabelsFile().RowGroups() {
-		rr, err := Filter(context.Background(), group, constraints...)
+	for i := range shard.LabelsFile().RowGroups() {
+		rr, err := Filter(context.Background(), shard.LabelsFile(), i, constraints...)
 		total := int64(0)
 		for _, r := range rr {
 			total += r.count

--- a/search/materialize_test.go
+++ b/search/materialize_test.go
@@ -136,7 +136,7 @@ func TestMaterializeE2E(t *testing.T) {
 	})
 }
 
-func convertToParquet(t *testing.T, ctx context.Context, bkt *filesystem.Bucket, data util.TestData, h convert.Convertible, opts ...storage.ShardOption) storage.ParquetShard {
+func convertToParquet(t *testing.T, ctx context.Context, bkt *filesystem.Bucket, data util.TestData, h convert.Convertible, opts ...storage.FileOption) storage.ParquetShard {
 	colDuration := time.Hour
 	shards, err := convert.ConvertTSDBBlock(
 		ctx,

--- a/search/materialize_test.go
+++ b/search/materialize_test.go
@@ -164,7 +164,7 @@ func convertToParquet(t *testing.T, ctx context.Context, bkt *filesystem.Bucket,
 func query(t *testing.T, mint, maxt int64, shard storage.ParquetShard, constraints ...Constraint) []prom_storage.ChunkSeries {
 	ctx := context.Background()
 	for _, c := range constraints {
-		require.NoError(t, c.init(shard))
+		require.NoError(t, c.init(shard.LabelsFile()))
 	}
 
 	s, err := shard.TSDBSchema()

--- a/storage/parquet_shard.go
+++ b/storage/parquet_shard.go
@@ -197,7 +197,6 @@ func NewParquetShardOpener(
 	shard int,
 	opts ...ShardOption,
 ) (*ParquetShardOpener, error) {
-
 	cfg := DefaultShardOptions
 
 	for _, opt := range opts {

--- a/storage/parquet_shard.go
+++ b/storage/parquet_shard.go
@@ -47,8 +47,6 @@ type ParquetFile struct {
 	*parquet.File
 	ReadAtWithContextCloser
 	Cfg ExtendedFileConfig
-
-	pagePartitioningMaxGapSize int
 }
 
 type FileOption func(*ExtendedFileConfig)
@@ -99,10 +97,9 @@ func Open(ctx context.Context, r ReadAtWithContextCloser, size int64, opts ...Fi
 	}
 
 	return &ParquetFile{
-		File:                       file,
-		ReadAtWithContextCloser:    r,
-		Cfg:                        cfg,
-		pagePartitioningMaxGapSize: cfg.PagePartitioningMaxGapSize,
+		File:                    file,
+		ReadAtWithContextCloser: r,
+		Cfg:                     cfg,
 	}, nil
 }
 
@@ -140,7 +137,6 @@ type ParquetShard interface {
 	LabelsFile() *ParquetFile
 	ChunksFile() *ParquetFile
 	TSDBSchema() (*schema.TSDBSchema, error)
-	Opts() ExtendedFileConfig
 }
 
 type ParquetOpener interface {
@@ -175,7 +171,6 @@ type ParquetShardOpener struct {
 	labelsFile, chunksFile *ParquetFile
 	schema                 *schema.TSDBSchema
 	o                      sync.Once
-	cfg                    ExtendedFileConfig
 }
 
 func NewParquetShardOpener(
@@ -216,12 +211,7 @@ func NewParquetShardOpener(
 	return &ParquetShardOpener{
 		labelsFile: labelsFile,
 		chunksFile: chunksFile,
-		cfg:        cfg,
 	}, nil
-}
-
-func (s *ParquetShardOpener) Opts() ExtendedFileConfig {
-	return s.cfg
 }
 
 func (s *ParquetShardOpener) LabelsFile() *ParquetFile {

--- a/storage/parquet_shard.go
+++ b/storage/parquet_shard.go
@@ -68,11 +68,17 @@ func (f *ParquetFile) GetPages(ctx context.Context, cc parquet.ColumnChunk, page
 		}
 		minOffset := offset.Offset(pagesToRead[0])
 		maxOffset := offset.Offset(pagesToRead[len(pagesToRead)-1]) + offset.CompressedPageSize(pagesToRead[len(pagesToRead)-1])
-		reader = newOptimisticReaderAt(reader, minOffset, maxOffset)
+		reader = NewOptimisticReaderAt(reader, minOffset, maxOffset)
 	}
 
 	pages := colChunk.PagesFrom(reader)
 	return pages, nil
+}
+
+func (f *ParquetFile) DictionaryPageBounds(rgIdx, colIdx int) (uint64, uint64) {
+	colMeta := f.Metadata().RowGroups[rgIdx].Columns[colIdx].MetaData
+
+	return uint64(colMeta.DictionaryPageOffset), uint64(colMeta.DataPageOffset - colMeta.DictionaryPageOffset)
 }
 
 func Open(ctx context.Context, r ReadAtWithContextCloser, size int64, opts ...ShardOption) (*ParquetFile, error) {

--- a/storage/parquet_shard.go
+++ b/storage/parquet_shard.go
@@ -67,17 +67,11 @@ func WithPageMaxGapSize(pagePartitioningMaxGapSize int) ShardOption {
 	}
 }
 
-func (f *ParquetFile) GetPages(ctx context.Context, cc parquet.ColumnChunk, pagesToRead ...int) (*parquet.FilePages, error) {
+func (f *ParquetFile) GetPages(ctx context.Context, cc parquet.ColumnChunk, minOffset, maxOffset int64) (*parquet.FilePages, error) {
 	colChunk := cc.(*parquet.FileColumnChunk)
 	reader := f.WithContext(ctx)
 
-	if len(pagesToRead) > 0 && f.optimisticReader {
-		offset, err := cc.OffsetIndex()
-		if err != nil {
-			return nil, err
-		}
-		minOffset := offset.Offset(pagesToRead[0])
-		maxOffset := offset.Offset(pagesToRead[len(pagesToRead)-1]) + offset.CompressedPageSize(pagesToRead[len(pagesToRead)-1])
+	if f.optimisticReader {
 		reader = NewOptimisticReaderAt(reader, minOffset, maxOffset)
 	}
 

--- a/storage/read_at.go
+++ b/storage/read_at.go
@@ -99,7 +99,7 @@ func (b optimisticReaderAt) ReadAt(p []byte, off int64) (n int, err error) {
 	return b.r.ReadAt(p, off)
 }
 
-func newOptimisticReaderAt(r io.ReaderAt, minOffset, maxOffset int64) io.ReaderAt {
+func NewOptimisticReaderAt(r io.ReaderAt, minOffset, maxOffset int64) io.ReaderAt {
 	if minOffset < maxOffset {
 		b := make([]byte, maxOffset-minOffset)
 		n, err := r.ReadAt(b, minOffset)


### PR DESCRIPTION
Optimizes equality matchers and improves dictionary handling during materialization:

* Optimized equality matcher: The Equal constraint now leverages the optimized read path to fetch all relevant data pages in a single read. This reduces overmatching and improves read efficiency - similar to what is done during the materialization phase: https://github.com/prometheus-community/parquet-common/pull/48
* Materialization improvements: The dictionary page is now included as part of the optimistic read during materialization. This avoids an additional object store call when decoding dictionary-encoded columns.
    
 Results compared to mainline:
 
 ```
goos: darwin
goarch: arm64
pkg: github.com/prometheus-community/parquet-common/queryable
cpu: Apple M1 Pro
                                        │   /tmp/old   │              /tmp/new               │
                                        │    sec/op    │    sec/op     vs base               │
Select/SingleMetricAllSeries-10           398.4m ±  8%   392.1m ±  3%   -1.58% (p=0.041 n=6)
Select/SingleMetricReducedSeries-10       29.33m ±  9%   23.19m ±  6%  -20.92% (p=0.002 n=6)
Select/SingleMetricOneSeries-10           26.88m ±  3%   21.40m ±  3%  -20.38% (p=0.002 n=6)
Select/SingleMetricSparseSeries-10        54.26m ±  6%   46.45m ±  9%  -14.39% (p=0.002 n=6)
Select/NonExistentSeries-10               25.47m ±  3%   19.48m ±  5%  -23.51% (p=0.002 n=6)
Select/MultipleMetricsRange-10             1.859 ±  4%    1.791 ±  3%   -3.64% (p=0.041 n=6)
Select/MultipleMetricsSparse-10           553.8m ±  8%   539.0m ±  6%        ~ (p=0.310 n=6)
Select/NegativeRegexSingleMetric-10       383.9m ±  7%   369.2m ±  5%        ~ (p=0.310 n=6)
Select/NegativeRegexMultipleMetrics-10     1.103 ±  3%    1.081 ±  7%        ~ (p=0.310 n=6)
Select/ExpensiveRegexSingleMetric-10      67.42m ± 12%   61.43m ± 16%        ~ (p=0.093 n=6)
Select/ExpensiveRegexMultipleMetrics-10   185.5m ±  3%   184.5m ±  4%        ~ (p=0.485 n=6)
geomean                                   164.4m         148.4m         -9.71%

                                        │      /tmp/old      │                  /tmp/new                   │
                                        │ bytes_get_range/op │ bytes_get_range/op  vs base                 │
Select/SingleMetricAllSeries-10                  9.137M ± 0%          5.774M ± 0%  -36.80% (p=0.002 n=6)
Select/SingleMetricReducedSeries-10             2029.3k ± 0%          423.4k ± 0%  -79.13% (p=0.002 n=6)
Select/SingleMetricOneSeries-10                 1978.0k ± 0%          376.5k ± 0%  -80.97% (p=0.002 n=6)
Select/SingleMetricSparseSeries-10               5.487M ± 0%          2.072M ± 0%  -62.25% (p=0.002 n=6)
Select/NonExistentSeries-10                     1938.7k ± 0%          366.6k ± 0%  -81.09% (p=0.002 n=6)
Select/MultipleMetricsRange-10                   38.01M ± 0%          30.84M ± 0%  -18.85% (p=0.002 n=6)
Select/MultipleMetricsSparse-10                  16.41M ± 0%          14.62M ± 0%  -10.91% (p=0.002 n=6)
Select/NegativeRegexSingleMetric-10              9.394M ± 0%          6.426M ± 0%  -31.60% (p=0.002 n=6)
Select/NegativeRegexMultipleMetrics-10           31.58M ± 0%          27.39M ± 0%  -13.27% (p=0.002 n=6)
Select/ExpensiveRegexSingleMetric-10             3.924M ± 0%          2.316M ± 0%  -40.97% (p=0.002 n=6)
Select/ExpensiveRegexMultipleMetrics-10          14.74M ± 0%          14.74M ± 0%        ~ (p=1.000 n=6) ¹
geomean                                          7.492M               3.721M       -50.33%
¹ all samples are equal

                                        │   /tmp/old   │              /tmp/new              │
                                        │    get/op    │   get/op    vs base                │
Select/SingleMetricAllSeries-10           0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=6) ¹
Select/SingleMetricReducedSeries-10       0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=6) ¹
Select/SingleMetricOneSeries-10           0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=6) ¹
Select/SingleMetricSparseSeries-10        0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=6) ¹
Select/NonExistentSeries-10               0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=6) ¹
Select/MultipleMetricsRange-10            0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=6) ¹
Select/MultipleMetricsSparse-10           0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=6) ¹
Select/NegativeRegexSingleMetric-10       0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=6) ¹
Select/NegativeRegexMultipleMetrics-10    0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=6) ¹
Select/ExpensiveRegexSingleMetric-10      0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=6) ¹
Select/ExpensiveRegexMultipleMetrics-10   0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=6) ¹
geomean                                              ²               +0.00%               ²
¹ all samples are equal
² summaries must be >0 to compute geomean

                                        │   /tmp/old   │               /tmp/new                │
                                        │ get_range/op │ get_range/op  vs base                 │
Select/SingleMetricAllSeries-10           19.163k ± 0%    8.400k ± 0%  -56.17% (p=0.002 n=6)
Select/SingleMetricReducedSeries-10       10.925k ± 0%    3.654k ± 0%  -66.55% (p=0.002 n=6)
Select/SingleMetricOneSeries-10           10.905k ± 0%    3.624k ± 0%  -66.77% (p=0.002 n=6)
Select/SingleMetricSparseSeries-10        18.001k ± 0%    6.000k ± 0%  -66.67% (p=0.002 n=6)
Select/NonExistentSeries-10               10.763k ± 0%    3.600k ± 0%  -66.55% (p=0.002 n=6)
Select/MultipleMetricsRange-10             72.41k ± 0%    58.01k ± 0%  -19.89% (p=0.002 n=6)
Select/MultipleMetricsSparse-10            47.21k ± 0%    43.61k ± 0%   -7.63% (p=0.002 n=6)
Select/NegativeRegexSingleMetric-10        25.08k ± 0%    15.11k ± 0%  -39.76% (p=0.002 n=6)
Select/NegativeRegexMultipleMetrics-10     81.76k ± 0%    73.33k ± 0%  -10.30% (p=0.002 n=6)
Select/ExpensiveRegexSingleMetric-10       18.69k ± 0%    11.46k ± 0%  -38.70% (p=0.002 n=6)
Select/ExpensiveRegexMultipleMetrics-10    62.10k ± 0%    62.10k ± 0%        ~ (p=1.000 n=6) ¹
geomean                                    25.95k         14.22k       -45.23%
¹ all samples are equal

                                        │   /tmp/old    │              /tmp/new               │
                                        │   series/op   │  series/op   vs base                │
Select/SingleMetricAllSeries-10           300.0k ± 0%     300.0k ± 0%       ~ (p=1.000 n=6) ¹
Select/SingleMetricReducedSeries-10       3.000k ± 0%     3.000k ± 0%       ~ (p=1.000 n=6) ¹
Select/SingleMetricOneSeries-10            1.000 ± 0%      1.000 ± 0%       ~ (p=1.000 n=6) ¹
Select/SingleMetricSparseSeries-10        5.000k ± 0%     5.000k ± 0%       ~ (p=1.000 n=6) ¹
Select/NonExistentSeries-10                0.000 ± 0%      0.000 ± 0%       ~ (p=1.000 n=6) ¹
Select/MultipleMetricsRange-10            1.200M ± 0%     1.200M ± 0%       ~ (p=1.000 n=6) ¹
Select/MultipleMetricsSparse-10           300.0k ± 0%     300.0k ± 0%       ~ (p=1.000 n=6) ¹
Select/NegativeRegexSingleMetric-10       234.0k ± 0%     234.0k ± 0%       ~ (p=1.000 n=6) ¹
Select/NegativeRegexMultipleMetrics-10    702.0k ± 0%     702.0k ± 0%       ~ (p=1.000 n=6) ¹
Select/ExpensiveRegexSingleMetric-10      6.000k ± 0%     6.000k ± 0%       ~ (p=1.000 n=6) ¹
Select/ExpensiveRegexMultipleMetrics-10    0.000 ± 0%      0.000 ± 0%       ~ (p=1.000 n=6) ¹
geomean                                               ²                +0.00%               ²
¹ all samples are equal
² summaries must be >0 to compute geomean

                                        │   /tmp/old   │              /tmp/new              │
                                        │     B/op     │     B/op      vs base              │
Select/SingleMetricAllSeries-10           777.0Mi ± 0%   775.3Mi ± 0%  -0.21% (p=0.002 n=6)
Select/SingleMetricReducedSeries-10       71.67Mi ± 0%   71.03Mi ± 0%  -0.89% (p=0.002 n=6)
Select/SingleMetricOneSeries-10           66.98Mi ± 0%   66.35Mi ± 0%  -0.94% (p=0.002 n=6)
Select/SingleMetricSparseSeries-10        131.1Mi ± 0%   130.3Mi ± 0%  -0.61% (p=0.002 n=6)
Select/NonExistentSeries-10               64.08Mi ± 0%   63.45Mi ± 0%  -0.98% (p=0.002 n=6)
Select/MultipleMetricsRange-10            3.108Gi ± 0%   3.104Gi ± 0%  -0.14% (p=0.002 n=6)
Select/MultipleMetricsSparse-10           1.033Gi ± 0%   1.032Gi ± 0%  -0.11% (p=0.002 n=6)
Select/NegativeRegexSingleMetric-10       716.1Mi ± 0%   714.7Mi ± 0%  -0.19% (p=0.002 n=6)
Select/NegativeRegexMultipleMetrics-10    2.170Gi ± 0%   2.167Gi ± 0%  -0.12% (p=0.002 n=6)
Select/ExpensiveRegexSingleMetric-10      192.7Mi ± 0%   192.2Mi ± 0%  -0.27% (p=0.002 n=6)
Select/ExpensiveRegexMultipleMetrics-10   539.8Mi ± 0%   539.8Mi ± 0%  -0.01% (p=0.002 n=6)
geomean                                   369.4Mi        367.9Mi       -0.41%

                                        │  /tmp/old   │              /tmp/new              │
                                        │  allocs/op  │  allocs/op   vs base               │
Select/SingleMetricAllSeries-10           9.845M ± 0%   9.780M ± 0%   -0.66% (p=0.002 n=6)
Select/SingleMetricReducedSeries-10       289.6k ± 0%   260.3k ± 0%  -10.11% (p=0.002 n=6)
Select/SingleMetricOneSeries-10           266.2k ± 0%   237.2k ± 0%  -10.93% (p=0.002 n=6)
Select/SingleMetricSparseSeries-10        647.9k ± 0%   597.8k ± 0%   -7.73% (p=0.002 n=6)
Select/NonExistentSeries-10               191.6k ± 0%   162.9k ± 0%  -14.96% (p=0.002 n=6)
Select/MultipleMetricsRange-10            39.71M ± 0%   39.56M ± 0%   -0.39% (p=0.002 n=6)
Select/MultipleMetricsSparse-10           10.82M ± 0%   10.78M ± 0%   -0.35% (p=0.002 n=6)
Select/NegativeRegexSingleMetric-10       8.353M ± 0%   8.296M ± 0%   -0.68% (p=0.002 n=6)
Select/NegativeRegexMultipleMetrics-10    24.50M ± 0%   24.41M ± 0%   -0.37% (p=0.002 n=6)
Select/ExpensiveRegexSingleMetric-10      915.6k ± 0%   888.0k ± 0%   -3.02% (p=0.002 n=6)
Select/ExpensiveRegexMultipleMetrics-10   1.796M ± 0%   1.796M ± 0%        ~ (p=0.108 n=6)
geomean                                   2.376M        2.266M        -4.62%
 ```
