### PR TITLE
Improving benchmark results

### DIFF
--- a/.github/workflows/benchmark-on-prs.yml
+++ b/.github/workflows/benchmark-on-prs.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           go-version: "stable"
       - name: Run benchmark
-        run: go test -bench=BenchmarkSelect -run=^$ ./queryable/... -benchtime=1s -count 5 | tee output.txt
+        run: go test -bench=BenchmarkSelect -run=^$ ./queryable/... -benchtime=10s | tee output.txt
 
       - name: Store benchmark result
         uses: benchmark-action/github-action-benchmark@v1

--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ Expect:
 - Incomplete or unstable features
 - Minimal documentation
 
+## Benchmarks Results 
+
+* https://prometheus-community.github.io/parquet-common/dev/bench/
 
 ## Usage 
 


### PR DESCRIPTION
Running the benchmark only 1 time for 10 seconds to only have 1 point on the benchmark graphs. 