### PR TITLE
Wrap error properly in fmt.Errorf

### DIFF
--- a/convert/convert.go
+++ b/convert/convert.go
@@ -226,25 +226,25 @@ func NewTsdbRowReader(ctx context.Context, mint, maxt, colDuration int64, blks [
 	for _, blk := range blks {
 		indexr, err := blk.Index()
 		if err != nil {
-			return nil, fmt.Errorf("unable to get index reader from block: %s", err)
+			return nil, fmt.Errorf("unable to get index reader from block: %w", err)
 		}
 		closers = append(closers, indexr)
 
 		chunkr, err := blk.Chunks()
 		if err != nil {
-			return nil, fmt.Errorf("unable to get chunk reader from block: %s", err)
+			return nil, fmt.Errorf("unable to get chunk reader from block: %w", err)
 		}
 		closers = append(closers, chunkr)
 
 		tombsr, err := blk.Tombstones()
 		if err != nil {
-			return nil, fmt.Errorf("unable to get tombstone reader from block: %s", err)
+			return nil, fmt.Errorf("unable to get tombstone reader from block: %w", err)
 		}
 		closers = append(closers, tombsr)
 
 		lblns, err := indexr.LabelNames(ctx)
 		if err != nil {
-			return nil, fmt.Errorf("unable to get label names from block: %s", err)
+			return nil, fmt.Errorf("unable to get label names from block: %w", err)
 		}
 
 		postings := sortedPostings(ctx, indexr, compareFunc, ops.sortedLabels...)
@@ -258,7 +258,7 @@ func NewTsdbRowReader(ctx context.Context, mint, maxt, colDuration int64, blks [
 
 	s, err := b.Build()
 	if err != nil {
-		return nil, fmt.Errorf("unable to build index reader from block: %s", err)
+		return nil, fmt.Errorf("unable to build index reader from block: %w", err)
 	}
 
 	return &TsdbRowReader{

--- a/convert/writer.go
+++ b/convert/writer.go
@@ -77,7 +77,7 @@ func (c *ShardedWriter) Write(ctx context.Context) error {
 func (c *ShardedWriter) convertShards(ctx context.Context) error {
 	for {
 		if ok, err := c.convertShard(ctx); err != nil {
-			return fmt.Errorf("unable to convert shard: %s", err)
+			return fmt.Errorf("unable to convert shard: %w", err)
 		} else if !ok {
 			break
 		}
@@ -125,17 +125,17 @@ func (c *ShardedWriter) writeFile(ctx context.Context, schema *schema.TSDBSchema
 		ctx, schema.Schema, c.outSchemasForCurrentShard(), c.pipeReaderWriter, fileOpts...,
 	)
 	if err != nil {
-		return 0, fmt.Errorf("unable to create row writer: %s", err)
+		return 0, fmt.Errorf("unable to create row writer: %w", err)
 	}
 
 	n, err := parquet.CopyRows(writer, newBufferedReader(ctx, newLimitReader(c.rr, rowsToWrite)))
 	if err != nil {
-		return 0, fmt.Errorf("unable to copy rows: %s", err)
+		return 0, fmt.Errorf("unable to copy rows: %w", err)
 	}
 
 	err = writer.Close()
 	if err != nil {
-		return 0, fmt.Errorf("unable to close writer: %s", err)
+		return 0, fmt.Errorf("unable to close writer: %w", err)
 	}
 
 	return n, nil
@@ -261,11 +261,11 @@ func (s *splitPipeFileWriter) WriteRows(rows []parquet.Row) (int, error) {
 			convertedRows := util.CloneRows(rows)
 			_, err := writer.conv.Convert(convertedRows)
 			if err != nil {
-				return fmt.Errorf("unable to convert rows: %d", err)
+				return fmt.Errorf("unable to convert rows: %w", err)
 			}
 			n, err := writer.pw.WriteRows(convertedRows)
 			if err != nil {
-				return fmt.Errorf("unable to write rows: %d", err)
+				return fmt.Errorf("unable to write rows: %w", err)
 			}
 			if n != len(rows) {
 				return fmt.Errorf("unable to write rows: %d != %d", n, len(rows))


### PR DESCRIPTION
We have a use case to capture the underlying error for some of our internal metrics so we need to preserve the underlying error in the error chain.

Currently, mostly in the convert path, we use `fmt.Errorf()` with `%s` which basically converts the error to a string and the error information is lost. This PR fixes this by using `%w` to wrap the error properly.