### PR TITLE
Add limiter

### DIFF
--- a/queryable/parquet_queryable.go
+++ b/queryable/parquet_queryable.go
@@ -42,13 +42,11 @@ type queryableOpts struct {
 }
 
 var DefaultQueryableOpts = queryableOpts{
-	concurrency:         runtime.GOMAXPROCS(0),
-	rowCountLimitFunc:   search.NoopQuotaLimitFunc,
-	chunkBytesLimitFunc: search.NoopQuotaLimitFunc,
-	dataBytesLimitFunc:  search.NoopQuotaLimitFunc,
-	materializedSeriesCallback: func(_ context.Context, _ []prom_storage.ChunkSeries) error {
-		return nil
-	},
+	concurrency:                runtime.GOMAXPROCS(0),
+	rowCountLimitFunc:          search.NoopQuotaLimitFunc,
+	chunkBytesLimitFunc:        search.NoopQuotaLimitFunc,
+	dataBytesLimitFunc:         search.NoopQuotaLimitFunc,
+	materializedSeriesCallback: search.NoopMaterializedSeriesFunc,
 }
 
 type QueryableOpts func(*queryableOpts)
@@ -60,24 +58,29 @@ func WithConcurrency(concurrency int) QueryableOpts {
 	}
 }
 
+// WithRowCountLimitFunc sets a callback function to get limit for matched row count.
 func WithRowCountLimitFunc(fn search.QuotaLimitFunc) QueryableOpts {
 	return func(opts *queryableOpts) {
 		opts.rowCountLimitFunc = fn
 	}
 }
 
+// WithChunkBytesLimitFunc sets a callback function to get limit for chunk column page bytes fetched.
 func WithChunkBytesLimitFunc(fn search.QuotaLimitFunc) QueryableOpts {
 	return func(opts *queryableOpts) {
 		opts.chunkBytesLimitFunc = fn
 	}
 }
 
+// WithDataBytesLimitFunc sets a callback function to get limit for data (including label and chunk)
+// column page bytes fetched.
 func WithDataBytesLimitFunc(fn search.QuotaLimitFunc) QueryableOpts {
 	return func(opts *queryableOpts) {
 		opts.dataBytesLimitFunc = fn
 	}
 }
 
+// WithMaterializedSeriesCallback sets a callback function to process the materialized series.
 func WithMaterializedSeriesCallback(fn search.MaterializedSeriesFunc) QueryableOpts {
 	return func(opts *queryableOpts) {
 		opts.materializedSeriesCallback = fn

--- a/search/limits.go
+++ b/search/limits.go
@@ -1,0 +1,76 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+// This package is a modified copy from
+// https://github.com/thanos-io/thanos-parquet-gateway/blob/cfc1279f605d1c629c4afe8b1e2a340e8b15ecdc/internal/limits/limit.go.
+
+package search
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+)
+
+type resourceExhausted struct {
+	used int64
+}
+
+func (re *resourceExhausted) Error() string {
+	return fmt.Sprintf("resource exhausted (used %d)", re.used)
+}
+
+func IsResourceExhausted(err error) bool {
+	var re *resourceExhausted
+	return errors.As(err, &re)
+}
+
+type Quota struct {
+	mu sync.Mutex
+	q  int64
+	u  int64
+}
+
+func NewQuota(n int64) *Quota {
+	return &Quota{q: n, u: n}
+}
+
+func UnlimitedQuota() *Quota {
+	return NewQuota(0)
+}
+
+func (q *Quota) Reserve(n int64) error {
+	if q.q == 0 {
+		return nil
+	}
+
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	if q.u-n < 0 {
+		return &resourceExhausted{used: q.q}
+	}
+	q.u -= n
+	return nil
+}
+
+type QuotaLimitFunc func(ctx context.Context) int64
+
+func NoopQuotaLimitFunc(ctx context.Context) int64 {
+	return 0
+}

--- a/search/limits.go
+++ b/search/limits.go
@@ -35,21 +35,25 @@ func (re *resourceExhausted) Error() string {
 	return fmt.Sprintf("resource exhausted (used %d)", re.used)
 }
 
+// IsResourceExhausted checks if the error is a resource exhausted error.
 func IsResourceExhausted(err error) bool {
 	var re *resourceExhausted
 	return errors.As(err, &re)
 }
 
+// Quota is a limiter for a resource.
 type Quota struct {
 	mu sync.Mutex
 	q  int64
 	u  int64
 }
 
+// NewQuota creates a new quota with the given limit.
 func NewQuota(n int64) *Quota {
 	return &Quota{q: n, u: n}
 }
 
+// UnlimitedQuota creates a new quota with no limit.
 func UnlimitedQuota() *Quota {
 	return NewQuota(0)
 }
@@ -69,8 +73,10 @@ func (q *Quota) Reserve(n int64) error {
 	return nil
 }
 
+// QuotaLimitFunc is a function that returns the limit value.
 type QuotaLimitFunc func(ctx context.Context) int64
 
+// NoopQuotaLimitFunc returns 0 which means no limit.
 func NoopQuotaLimitFunc(ctx context.Context) int64 {
 	return 0
 }

--- a/search/limits_test.go
+++ b/search/limits_test.go
@@ -1,0 +1,148 @@
+package search
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsResourceExhausted(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "resource exhausted error",
+			err:      &resourceExhausted{used: 100},
+			expected: true,
+		},
+		{
+			name:     "wrapped resource exhausted error",
+			err:      fmt.Errorf("wrapped: %w", &resourceExhausted{used: 50}),
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := IsResourceExhausted(tt.err)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestQuota_Reserve(t *testing.T) {
+	tests := []struct {
+		name         string
+		quotaLimit   int64
+		reservations []int64
+		expectError  bool
+	}{
+		{
+			name:         "reserve within limit",
+			quotaLimit:   100,
+			reservations: []int64{30, 40, 20},
+			expectError:  false,
+		},
+		{
+			name:         "reserve exact limit",
+			quotaLimit:   100,
+			reservations: []int64{100},
+			expectError:  false,
+		},
+		{
+			name:         "reserve beyond limit",
+			quotaLimit:   100,
+			reservations: []int64{50, 60},
+			expectError:  true,
+		},
+		{
+			name:         "reserve zero amount",
+			quotaLimit:   100,
+			reservations: []int64{0},
+			expectError:  false,
+		},
+		{
+			name:         "reserve negative amount",
+			quotaLimit:   100,
+			reservations: []int64{-10},
+			expectError:  false, // This should work as it increases available quota
+		},
+		{
+			name:         "unlimited quota",
+			quotaLimit:   0,
+			reservations: []int64{1000, 2000, 3000},
+			expectError:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			quota := NewQuota(tt.quotaLimit)
+			var lastErr error
+
+			for _, amount := range tt.reservations {
+				err := quota.Reserve(amount)
+				if err != nil {
+					lastErr = err
+					require.True(t, IsResourceExhausted(err), "Expected resource exhausted error")
+					break
+				}
+			}
+
+			if tt.expectError {
+				require.Error(t, lastErr, "Expected error but got none")
+			} else {
+				require.NoError(t, lastErr, "Unexpected error")
+			}
+		})
+	}
+}
+
+func TestQuota_ConcurrentReserve(t *testing.T) {
+	quota := NewQuota(1000)
+	const numGoroutines = 10
+	const reservationAmount = 100
+
+	// Use a channel to collect errors from goroutines
+	errChan := make(chan error, numGoroutines)
+
+	// Start multiple goroutines trying to reserve simultaneously
+	for i := 0; i < numGoroutines; i++ {
+		go func() {
+			err := quota.Reserve(reservationAmount)
+			errChan <- err
+		}()
+	}
+
+	// Collect all errors
+	var errors []error
+	for i := 0; i < numGoroutines; i++ {
+		err := <-errChan
+		errors = append(errors, err)
+	}
+
+	// Should have exactly 10 successful reservations (1000 total)
+	successCount := 0
+	exhaustedCount := 0
+	for _, err := range errors {
+		if err == nil {
+			successCount++
+		} else if IsResourceExhausted(err) {
+			exhaustedCount++
+		} else {
+			require.Fail(t, "Unexpected error type", "error: %v", err)
+		}
+	}
+
+	expectedSuccess := 10 // 1000 / 100 = 10
+	require.Equal(t, expectedSuccess, successCount, "Expected %d successful reservations", expectedSuccess)
+	require.Equal(t, 0, exhaustedCount, "Expected 0 exhausted errors")
+
+	// Next reservation should fail
+	err := quota.Reserve(1)
+	require.Error(t, err, "Expected error when reserving beyond quota limit")
+	require.True(t, IsResourceExhausted(err), "Expected resource exhausted error")
+}

--- a/search/materialize.go
+++ b/search/materialize.go
@@ -56,6 +56,11 @@ type Materializer struct {
 // materialized series.
 type MaterializedSeriesFunc func(ctx context.Context, series []prom_storage.ChunkSeries) error
 
+// NoopMaterializedSeriesFunc is a noop callback function that does nothing.
+func NoopMaterializedSeriesFunc(_ context.Context, _ []prom_storage.ChunkSeries) error {
+	return nil
+}
+
 func NewMaterializer(s *schema.TSDBSchema,
 	d *schema.PrometheusParquetChunksDecoder,
 	block storage.ParquetShard,

--- a/search/materialize_test.go
+++ b/search/materialize_test.go
@@ -110,7 +110,7 @@ func TestMaterializeE2E(t *testing.T) {
 		s, err := shard.TSDBSchema()
 		require.NoError(t, err)
 		d := schema.NewPrometheusParquetChunksDecoder(chunkenc.NewPool())
-		m, err := NewMaterializer(s, d, shard, 10)
+		m, err := NewMaterializer(s, d, shard, 10, UnlimitedQuota(), UnlimitedQuota(), UnlimitedQuota(), NoopMaterializedSeriesFunc)
 		require.NoError(t, err)
 		rr := []RowRange{{from: int64(0), count: shard.LabelsFile().RowGroups()[0].NumRows()}}
 		ctx, cancel := context.WithCancel(ctx)
@@ -128,11 +128,95 @@ func TestMaterializeE2E(t *testing.T) {
 		s, err := shard.TSDBSchema()
 		require.NoError(t, err)
 		d := schema.NewPrometheusParquetChunksDecoder(chunkenc.NewPool())
-		m, err := NewMaterializer(s, d, shard, 10)
+		m, err := NewMaterializer(s, d, shard, 10, UnlimitedQuota(), UnlimitedQuota(), UnlimitedQuota(), NoopMaterializedSeriesFunc)
 		require.NoError(t, err)
 		rr := []RowRange{{from: int64(0), count: shard.LabelsFile().RowGroups()[0].NumRows()}}
 		_, err = m.Materialize(ctx, 0, data.MinTime, data.MaxTime, false, rr)
 		require.NoError(t, err)
+	})
+
+	t.Run("RowCountQuota", func(t *testing.T) {
+		s, err := shard.TSDBSchema()
+		require.NoError(t, err)
+		d := schema.NewPrometheusParquetChunksDecoder(chunkenc.NewPool())
+
+		// Test with limited row count quota
+		limitedRowCountQuota := NewQuota(10) // Only allow 10 rows
+		m, err := NewMaterializer(s, d, shard, 10, limitedRowCountQuota, UnlimitedQuota(), UnlimitedQuota(), NoopMaterializedSeriesFunc)
+		require.NoError(t, err)
+
+		// Try to materialize more rows than quota allows
+		rr := []RowRange{{from: int64(0), count: 20}} // 20 rows
+		_, err = m.Materialize(ctx, 0, data.MinTime, data.MaxTime, false, rr)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "would fetch too many rows")
+		require.True(t, IsResourceExhausted(err))
+
+		// Test with sufficient quota
+		sufficientRowCountQuota := NewQuota(1000) // Allow 1000 rows
+		m, err = NewMaterializer(s, d, shard, 10, sufficientRowCountQuota, UnlimitedQuota(), UnlimitedQuota(), NoopMaterializedSeriesFunc)
+		require.NoError(t, err)
+
+		rr = []RowRange{{from: int64(0), count: 50}} // 50 rows
+		series, err := m.Materialize(ctx, 0, data.MinTime, data.MaxTime, false, rr)
+		require.NoError(t, err)
+		require.NotEmpty(t, series)
+	})
+
+	t.Run("ChunkBytesQuota", func(t *testing.T) {
+		s, err := shard.TSDBSchema()
+		require.NoError(t, err)
+		d := schema.NewPrometheusParquetChunksDecoder(chunkenc.NewPool())
+
+		// Test with limited chunk bytes quota
+		limitedChunkBytesQuota := NewQuota(100) // Only allow 100 bytes
+		m, err := NewMaterializer(s, d, shard, 10, UnlimitedQuota(), limitedChunkBytesQuota, UnlimitedQuota(), NoopMaterializedSeriesFunc)
+		require.NoError(t, err)
+
+		// Try to materialize chunks that exceed the quota
+		rr := []RowRange{{from: int64(0), count: 100}} // Large range to trigger chunk reading
+		_, err = m.Materialize(ctx, 0, data.MinTime, data.MaxTime, false, rr)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "would fetch too many chunk bytes")
+		require.True(t, IsResourceExhausted(err))
+
+		// Test with sufficient quota
+		sufficientChunkBytesQuota := NewQuota(1000000) // Allow 1MB
+		m, err = NewMaterializer(s, d, shard, 10, UnlimitedQuota(), sufficientChunkBytesQuota, UnlimitedQuota(), NoopMaterializedSeriesFunc)
+		require.NoError(t, err)
+
+		rr = []RowRange{{from: int64(0), count: 10}} // Small range
+		series, err := m.Materialize(ctx, 0, data.MinTime, data.MaxTime, false, rr)
+		require.NoError(t, err)
+		require.NotEmpty(t, series)
+	})
+
+	t.Run("DataBytesQuota", func(t *testing.T) {
+		s, err := shard.TSDBSchema()
+		require.NoError(t, err)
+		d := schema.NewPrometheusParquetChunksDecoder(chunkenc.NewPool())
+
+		// Test with limited data bytes quota
+		limitedDataBytesQuota := NewQuota(100) // Only allow 100 bytes
+		m, err := NewMaterializer(s, d, shard, 10, UnlimitedQuota(), UnlimitedQuota(), limitedDataBytesQuota, NoopMaterializedSeriesFunc)
+		require.NoError(t, err)
+
+		// Try to materialize data that exceeds the quota
+		rr := []RowRange{{from: int64(0), count: 100}} // Large range to trigger data reading
+		_, err = m.Materialize(ctx, 0, data.MinTime, data.MaxTime, false, rr)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "would fetch too many data bytes")
+		require.True(t, IsResourceExhausted(err))
+
+		// Test with sufficient quota
+		sufficientDataBytesQuota := NewQuota(1000000) // Allow 1MB
+		m, err = NewMaterializer(s, d, shard, 10, UnlimitedQuota(), UnlimitedQuota(), sufficientDataBytesQuota, NoopMaterializedSeriesFunc)
+		require.NoError(t, err)
+
+		rr = []RowRange{{from: int64(0), count: 10}} // Small range
+		series, err := m.Materialize(ctx, 0, data.MinTime, data.MaxTime, false, rr)
+		require.NoError(t, err)
+		require.NotEmpty(t, series)
 	})
 }
 
@@ -170,7 +254,7 @@ func query(t *testing.T, mint, maxt int64, shard storage.ParquetShard, constrain
 	s, err := shard.TSDBSchema()
 	require.NoError(t, err)
 	d := schema.NewPrometheusParquetChunksDecoder(chunkenc.NewPool())
-	m, err := NewMaterializer(s, d, shard, 10)
+	m, err := NewMaterializer(s, d, shard, 10, UnlimitedQuota(), UnlimitedQuota(), UnlimitedQuota(), NoopMaterializedSeriesFunc)
 	require.NoError(t, err)
 
 	found := make([]prom_storage.ChunkSeries, 0, 100)


### PR DESCRIPTION
This PR tries to add some limiters similar to thanos parquet gateway https://github.com/thanos-io/thanos-parquet-gateway/blob/cfc1279f605d1c629c4afe8b1e2a340e8b15ecdc/internal/limits/limit.go.

Now 3 limiters are added using quota:
- Matched row count (before chunk materialize)
- Chunk pages bytes fetched
- Data pages bytes fetched (including labels and chunks)

Also introduced a `materializedSeriesCallback` which is a hook that takes the final materialized chunk series set. This allows injecting custom limiter logic as well as doing some stats counting.

This PR doesn't have any tests now. Just open to gather feedback and see if it is on the right direction