### PR TITLE
create ParquetFileView as interface covering ParquetFile behavior

### DIFF
--- a/convert/convert_test.go
+++ b/convert/convert_test.go
@@ -190,7 +190,7 @@ func Test_CreateParquetWithReducedTimestampSamples(t *testing.T) {
 	require.NoError(t, err)
 
 	// Check metadatas
-	for _, file := range []*storage.ParquetFile{shard.LabelsFile(), shard.ChunksFile()} {
+	for _, file := range []storage.ParquetFileView{shard.LabelsFile(), shard.ChunksFile()} {
 		require.Equal(t, schema.MetadataToMap(file.Metadata().KeyValueMetadata)[schema.MinTMd], strconv.FormatInt(mint, 10))
 		require.Equal(t, schema.MetadataToMap(file.Metadata().KeyValueMetadata)[schema.MaxTMd], strconv.FormatInt(maxt, 10))
 		require.Equal(t, schema.MetadataToMap(file.Metadata().KeyValueMetadata)[schema.DataColSizeMd], strconv.FormatInt(datColDuration.Milliseconds(), 10))
@@ -385,8 +385,9 @@ func Test_SortedLabels(t *testing.T) {
 }
 
 func readSeries(t *testing.T, shard storage.ParquetShard) ([]labels.Labels, [][]chunks.Meta, error) {
-	lr := parquet.NewGenericReader[any](shard.LabelsFile().File)
-	cr := parquet.NewGenericReader[any](shard.ChunksFile().File)
+	ctx := context.Background()
+	lr := parquet.NewGenericReader[any](shard.LabelsFile().WithContext(ctx))
+	cr := parquet.NewGenericReader[any](shard.ChunksFile().WithContext(ctx))
 
 	labelsBuff := make([]parquet.Row, 100)
 	chunksBuff := make([]parquet.Row, 100)

--- a/search/materialize.go
+++ b/search/materialize.go
@@ -117,7 +117,7 @@ func NewMaterializer(s *schema.TSDBSchema,
 		b:                                block,
 		colIdx:                           colIdx.ColumnIndex,
 		concurrency:                      concurrency,
-		partitioner:                      util.NewGapBasedPartitioner(block.ChunksFile().Cfg.PagePartitioningMaxGapSize),
+		partitioner:                      util.NewGapBasedPartitioner(block.ChunksFile().PagePartitioningMaxGapSize()),
 		dataColToIndex:                   dataColToIndex,
 		rowCountQuota:                    rowCountQuota,
 		chunkBytesQuota:                  chunkBytesQuota,
@@ -473,7 +473,7 @@ func (m *Materializer) materializeChunks(ctx context.Context, rgi int, mint, max
 	return r, nil
 }
 
-func (m *Materializer) materializeColumn(ctx context.Context, file *storage.ParquetFile, rgi int, cc parquet.ColumnChunk, rr []RowRange, chunkColumn bool) ([]parquet.Value, error) {
+func (m *Materializer) materializeColumn(ctx context.Context, file storage.ParquetFileView, rgi int, cc parquet.ColumnChunk, rr []RowRange, chunkColumn bool) ([]parquet.Value, error) {
 	if len(rr) == 0 {
 		return nil, nil
 	}
@@ -534,7 +534,7 @@ func (m *Materializer) materializeColumn(ctx context.Context, file *storage.Parq
 			maxOffset := uint64(p.off + p.csz)
 
 			// if dictOff == 0, it means that the collum is not dictionary encoded
-			if dictOff > 0 && int(minOffset-(dictOff+dictSz)) < file.Cfg.PagePartitioningMaxGapSize {
+			if dictOff > 0 && int(minOffset-(dictOff+dictSz)) < file.PagePartitioningMaxGapSize() {
 				minOffset = dictOff
 			}
 


### PR DESCRIPTION
This stems from Mimir's usage of of file lifecycle management where we hold files open for reading by multiple consumers, and only close files when they have not been read for some time.

In order to do this, we need the Parquet shard/file behaviors to be an interface which we can implement by wrapping the underlying concrete type with atomic counters for tracking active readers.

`ParquetFile` is now an implementation of the `ParquetFileView` interface (mirroring upstreams usage of the FileView interface name) which covers all the behavior we get from ParquetFile. This includes access to its concrete ExtendedFileConfig, which is now an implementation of the interface ParquetFileConfigView.