### PR TITLE
fix(search): constraint filtering panics with out of index

### DIFF
--- a/queryable/parquet_queryable.go
+++ b/queryable/parquet_queryable.go
@@ -357,7 +357,7 @@ func (b queryableShard) Query(ctx context.Context, sorted bool, sp *prom_storage
 
 	for rgi := range b.shard.LabelsFile().RowGroups() {
 		errGroup.Go(func() error {
-			cs, err := search.MatchersToConstraint(matchers...)
+			cs, err := search.MatchersToConstraints(matchers...)
 			if err != nil {
 				return err
 			}
@@ -411,7 +411,7 @@ func (b queryableShard) LabelNames(ctx context.Context, limit int64, matchers []
 
 	for rgi := range b.shard.LabelsFile().RowGroups() {
 		errGroup.Go(func() error {
-			cs, err := search.MatchersToConstraint(matchers...)
+			cs, err := search.MatchersToConstraints(matchers...)
 			if err != nil {
 				return err
 			}
@@ -451,7 +451,7 @@ func (b queryableShard) LabelValues(ctx context.Context, name string, limit int6
 
 	for rgi := range b.shard.LabelsFile().RowGroups() {
 		errGroup.Go(func() error {
-			cs, err := search.MatchersToConstraint(matchers...)
+			cs, err := search.MatchersToConstraints(matchers...)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Updated filter function by sorting with slices.sort instead of custom
loop that led to out of index.

Also updated unit tests for queryable and constraint filter

Note, **breaking**,  also renamed MatchersToConstraint into MatchersToConstraints

```
panic: runtime error: index out of range [2] with length 2

goroutine 46490 [running]:
github.com/prometheus-community/parquet-common/search.Filter({0x4f5a5d0, 0xc02fab8a00}, {0x7c89d5a0e900?, 0xc02f9e4de0?}, 0x0, {0xc02f95bca0, 0x2, 0xc01af08330?})
        vendor/github.com/prometheus-community/parquet-common/search/constraint.go:91 +0x473
github.com/grafana/mimir/pkg/storage/parquet.queryableShard.Query.func1()
       vendor/github.com/grafana/mimir/pkg/storage/parquet/queryable_shard.go:60 +0x13e
golang.org/x/sync/errgroup.(*Group).Go.func1()
        vendor/golang.org/x/sync/errgroup/errgroup.go:93 +0x50
created by golang.org/x/sync/errgroup.(*Group).Go in goroutine 46489
        vendor/golang.org/x/sync/errgroup/errgroup.go:78 +0x93
```