### PR TITLE
set shards count in span before query execution

### DIFF
--- a/search/constraint_test.go
+++ b/search/constraint_test.go
@@ -513,9 +513,9 @@ type mockConstraint struct {
 	pathName string
 }
 
-func (m *mockConstraint) String() string                    { return fmt.Sprintf("mock(%s)", m.pathName) }
-func (m *mockConstraint) path() string                      { return m.pathName }
-func (m *mockConstraint) init(f *storage.ParquetFile) error { return nil }
+func (m *mockConstraint) String() string                       { return fmt.Sprintf("mock(%s)", m.pathName) }
+func (m *mockConstraint) path() string                         { return m.pathName }
+func (m *mockConstraint) init(f storage.ParquetFileView) error { return nil }
 func (m *mockConstraint) filter(ctx context.Context, rgIdx int, primary bool, rr []RowRange) ([]RowRange, error) {
 	return rr, nil
 }


### PR DESCRIPTION
Set shard count attribute in span before running the query. In `Select` today we only set shard count attribute after Select is done successfully. This could miss the attribute if the query returns an error