### PR TITLE
Regex constraint: skip pages with min/max and regex set matches

### DIFF
--- a/search/constraint_test.go
+++ b/search/constraint_test.go
@@ -392,6 +392,14 @@ func TestFilter(t *testing.T) {
 							{From: 0, Count: 4},
 						},
 					},
+					{
+						constraints: []Constraint{
+							Regex("C", mustNewFastRegexMatcher(t, "foo|bar")),
+						},
+						expect: []RowRange{
+							{From: 0, Count: 3},
+						},
+					},
 				},
 			},
 			{

--- a/search/materialize.go
+++ b/search/materialize.go
@@ -570,7 +570,6 @@ func (m *Materializer) materializeColumn(ctx context.Context, file storage.Parqu
 	errGroup.SetLimit(m.concurrency)
 
 	dictOff, dictSz := file.DictionaryPageBounds(rgi, cc.Column())
-	cc.Type()
 
 	for _, p := range pageRanges {
 		errGroup.Go(func() error {


### PR DESCRIPTION
Skip pages using min/max stats and regex set matches.

I will add prefix support in future PRs. But seems today prefix is not exposed via FastRegexMatcher