### PR TITLE
convert: add optional timeranges column to chunks file

### DIFF
--- a/schema/encoder_test.go
+++ b/schema/encoder_test.go
@@ -54,7 +54,7 @@ load_with_nhcb 1m
 	require.NoError(t, app.Commit())
 
 	mint, maxt := ts.Head().MinTime(), ts.Head().MaxTime()
-	sb := NewBuilder(mint, maxt, (time.Minute * 60).Milliseconds())
+	sb := NewBuilder(mint, maxt, (time.Minute * 60).Milliseconds(), true)
 	s, err := sb.Build()
 	maxSamplesPerChunk := 30
 	enc := NewPrometheusParquetChunksEncoder(s, maxSamplesPerChunk)
@@ -82,8 +82,9 @@ load_with_nhcb 1m
 			chks[i].Chunk = c
 			totalSamples += c.NumSamples()
 		}
-		decodedChunksByTime, err := enc.Encode(storage.NewListChunkSeriesIterator(chks...))
+		decodedChunksByTime, timeranges, err := enc.Encode(storage.NewListChunkSeriesIterator(chks...))
 		require.NoError(t, err)
+		require.NotEmpty(t, timeranges)
 		for _, chunksByTime := range decodedChunksByTime {
 			decodedChunkMeta, err := dec.Decode(chunksByTime, mint, maxt)
 			require.NoError(t, err)

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -28,6 +28,7 @@ const (
 	LabelColumnPrefix = "l_"
 	DataColumnPrefix  = "s_data_"
 	ColIndexes        = "s_col_indexes"
+	ChunkTimeranges   = "s_chunk_timeranges"
 
 	DataColSizeMd = "data_col_duration_ms"
 	MinTMd        = "minT"

--- a/schema/schema_builder_test.go
+++ b/schema/schema_builder_test.go
@@ -43,7 +43,7 @@ func Test_DataCols(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(fmt.Sprintf("%d,%d,%d", tc.mint, tc.maxt, tc.dataColDuration), func(t *testing.T) {
-			b := NewBuilder(tc.mint, tc.maxt, tc.dataColDuration)
+			b := NewBuilder(tc.mint, tc.maxt, tc.dataColDuration, false)
 			s, err := b.Build()
 			require.NoError(t, err)
 			require.Len(t, s.DataColsIndexes, tc.expected)
@@ -52,7 +52,7 @@ func Test_DataCols(t *testing.T) {
 }
 
 func Test_LabelCols(t *testing.T) {
-	b := NewBuilder(0, time.Hour.Milliseconds(), time.Hour.Milliseconds())
+	b := NewBuilder(0, time.Hour.Milliseconds(), time.Hour.Milliseconds(), false)
 	b.AddLabelNameColumn("test", labels.MetricName)
 	s, err := b.Build()
 	require.NoError(t, err)
@@ -107,7 +107,7 @@ func Test_DataColumIdx(t *testing.T) {
 
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("case-%d", i), func(t *testing.T) {
-			b := NewBuilder(tc.mint, tc.maxt, tc.dataColDuration)
+			b := NewBuilder(tc.mint, tc.maxt, tc.dataColDuration, false)
 			s, err := b.Build()
 			require.NoError(t, err)
 

--- a/search/materialize.go
+++ b/search/materialize.go
@@ -278,7 +278,7 @@ func (m *Materializer) MaterializeLabelNames(ctx context.Context, rgi int, rr []
 	for _, colsIdx := range colsIdxs {
 		key := util.YoloString(colsIdx.ByteArray())
 		if _, ok := seen[key]; !ok {
-			idxs, err := schema.DecodeUintSlice(colsIdx.ByteArray())
+			idxs, err := schema.DecodeUintSlice[int](colsIdx.ByteArray())
 			if err != nil {
 				return nil, errors.Wrap(err, "failed to decode column index")
 			}
@@ -479,7 +479,7 @@ func (m *Materializer) buildColumnMappings(rr []RowRange, columnIndexes []parque
 
 		// Process each row in the current range
 		for rowInRange := int64(0); rowInRange < rowRange.Count; rowInRange++ {
-			columnIds, err := schema.DecodeUintSlice(columnIndexes[columnIndexPos].ByteArray())
+			columnIds, err := schema.DecodeUintSlice[int](columnIndexes[columnIndexPos].ByteArray())
 			columnIndexPos++
 
 			if err != nil {


### PR DESCRIPTION
This column is useful to determine whether a series has chunks overlapping with the queried timerange, without actually fetching the entire chunks.