### PR TITLE
optimize symbols reset and values iterator next

### DIFF
--- a/search/constraint.go
+++ b/search/constraint.go
@@ -260,6 +260,33 @@ func (s *SymbolTable) Reset(pg parquet.Page) {
 	s.dict = dict
 }
 
+func (s *SymbolTable) ResetWithRange(pg parquet.Page, l, r int) {
+	dict := pg.Dictionary()
+	data := pg.Data()
+	syms := data.Int32()
+	s.defs = pg.DefinitionLevels()
+
+	if s.syms == nil {
+		s.syms = make([]int32, len(s.defs))
+	} else {
+		s.syms = slices.Grow(s.syms, len(s.defs))[:len(s.defs)]
+	}
+
+	sidx := 0
+	for i := 0; i < l; i++ {
+		if s.defs[i] == 1 {
+			sidx++
+		}
+	}
+	for i := l; i < r; i++ {
+		if s.defs[i] == 1 {
+			s.syms[i] = syms[sidx]
+			sidx++
+		}
+	}
+	s.dict = dict
+}
+
 type equalConstraint struct {
 	pth string
 
@@ -392,8 +419,6 @@ func (ec *equalConstraint) filter(ctx context.Context, rgIdx int, primary bool, 
 			return nil, fmt.Errorf("unable to read page: %w", err)
 		}
 
-		symbols.Reset(pg)
-
 		// The page has the value, we need to find the matching row ranges
 		n := int(pg.NumRows())
 		bl := int(max(pfrom, from) - pfrom)
@@ -401,6 +426,7 @@ func (ec *equalConstraint) filter(ctx context.Context, rgIdx int, primary bool, 
 		var l, r int
 		switch {
 		case cidx.IsAscending() && primary:
+			symbols.Reset(pg)
 			l = sort.Search(n, func(i int) bool { return ec.comp(ec.val, symbols.Get(i)) <= 0 })
 			r = sort.Search(n, func(i int) bool { return ec.comp(ec.val, symbols.Get(i)) < 0 })
 
@@ -409,6 +435,7 @@ func (ec *equalConstraint) filter(ctx context.Context, rgIdx int, primary bool, 
 			}
 		default:
 			off, count := bl, 0
+			symbols.ResetWithRange(pg, bl, br)
 			for j := bl; j < br; j++ {
 				if !ec.matches(symbols.Get(j)) {
 					if count != 0 {
@@ -480,20 +507,25 @@ func Regex(path string, r *labels.Matcher) (Constraint, error) {
 	if r.Type != labels.MatchRegexp {
 		return nil, fmt.Errorf("unsupported matcher type: %s", r.Type)
 	}
-	return &regexConstraint{pth: path, cache: make(map[parquet.Value]bool), r: r}, nil
+	return &regexConstraint{
+		pth:   path,
+		cache: make(map[int32]bool),
+		r:     r,
+	}, nil
 }
 
 type regexConstraint struct {
 	f     storage.ParquetFileView
 	pth   string
-	cache map[parquet.Value]bool
+	cache map[int32]bool
 
 	// if its a "set" or "prefix" regex
 	// for set, those are minv and maxv of the set, for prefix minv is the prefix, maxv is prefix+max(charset)*16
 	minv parquet.Value
 	maxv parquet.Value
 
-	r *labels.Matcher
+	r            *labels.Matcher
+	matchesEmpty bool
 
 	comp func(l, r parquet.Value) int
 }
@@ -514,7 +546,7 @@ func (rc *regexConstraint) filter(ctx context.Context, rgIdx int, primary bool, 
 	if !ok {
 		// If match empty, return rr (filter nothing)
 		// otherwise return empty
-		if rc.matches(parquet.ValueOf("")) {
+		if rc.matchesEmpty {
 			return rr, nil
 		}
 		return []RowRange{}, nil
@@ -551,7 +583,7 @@ func (rc *regexConstraint) filter(ctx context.Context, rgIdx int, primary bool, 
 		}
 		// Page intersects [from, to] but we might be able to discard it with statistics
 		if cidx.NullPage(i) {
-			if rc.matches(parquet.ValueOf("")) {
+			if rc.matchesEmpty {
 				res = append(res, RowRange{pfrom, pcount})
 			}
 			continue
@@ -560,13 +592,13 @@ func (rc *regexConstraint) filter(ctx context.Context, rgIdx int, primary bool, 
 		// This works for i.e.: 'pod_name=~"thanos-.*"' or 'status_code=~"403|404"'
 		minv, maxv := cidx.MinValue(i), cidx.MaxValue(i)
 		if !rc.minv.IsNull() && !rc.maxv.IsNull() {
-			if !rc.matches(parquet.ValueOf("")) && !maxv.IsNull() && rc.comp(rc.minv, maxv) > 0 {
+			if !rc.matchesEmpty && !maxv.IsNull() && rc.comp(rc.minv, maxv) > 0 {
 				if cidx.IsDescending() {
 					break
 				}
 				continue
 			}
-			if !rc.matches(parquet.ValueOf("")) && !minv.IsNull() && rc.comp(rc.maxv, minv) < 0 {
+			if !rc.matchesEmpty && !minv.IsNull() && rc.comp(rc.maxv, minv) < 0 {
 				if cidx.IsAscending() {
 					break
 				}
@@ -614,15 +646,14 @@ func (rc *regexConstraint) filter(ctx context.Context, rgIdx int, primary bool, 
 			return nil, fmt.Errorf("unable to read page: %w", err)
 		}
 
-		symbols.Reset(pg)
-
 		// The page has the value, we need to find the matching row ranges
 		n := int(pg.NumRows())
 		bl := int(max(pfrom, from) - pfrom)
 		br := n - int(pto-min(pto, to))
 		off, count := bl, 0
+		symbols.ResetWithRange(pg, bl, br)
 		for j := bl; j < br; j++ {
-			if !rc.matches(symbols.Get(j)) {
+			if !rc.matches(symbols, symbols.GetIndex(j)) {
 				if count != 0 {
 					res = append(res, RowRange{pfrom + int64(off), int64(count)})
 				}
@@ -649,13 +680,14 @@ func (rc *regexConstraint) filter(ctx context.Context, rgIdx int, primary bool, 
 func (rc *regexConstraint) init(f storage.ParquetFileView) error {
 	c, ok := f.Schema().Lookup(rc.path())
 	rc.f = f
+	rc.matchesEmpty = rc.r.Matches("")
 	if !ok {
 		return nil
 	}
 	if stringKind := parquet.String().Type().Kind(); c.Node.Type().Kind() != stringKind {
 		return fmt.Errorf("schema: cannot search value of kind %s in column of kind %s", stringKind, c.Node.Type().Kind())
 	}
-	rc.cache = make(map[parquet.Value]bool)
+	rc.cache = make(map[int32]bool)
 	rc.comp = c.Node.Type().Compare
 
 	// if applicable compute the minv and maxv of the implied set of matches
@@ -681,11 +713,18 @@ func (rc *regexConstraint) path() string {
 	return rc.pth
 }
 
-func (rc *regexConstraint) matches(v parquet.Value) bool {
-	accept, seen := rc.cache[v]
+func (rc *regexConstraint) matches(symbols *SymbolTable, i int32) bool {
+	accept, seen := rc.cache[i]
 	if !seen {
+		var v parquet.Value
+		switch i {
+		case -1:
+			v = parquet.NullValue()
+		default:
+			v = symbols.dict.Index(i)
+		}
 		accept = rc.r.Matches(util.YoloString(v.ByteArray()))
-		rc.cache[v] = accept
+		rc.cache[i] = accept
 	}
 	return accept
 }


### PR DESCRIPTION
### Summary

This PR contains several small optimizations to constraint and materialize code:
- When reset symbol table, add `ResetWithRange` method to only load value symbols between index 0 and right bound. This might help if right bound r is much smaller than number of values in the page.
- Change regex constraint cache from `map[parquet.Value]bool` to `map[int32]bool` where the cache key is the dict symbol index. This doesn't reduce total number of regex we need to do but `map[int32]bool` should be cheaper during hashmap lookup in Go. See https://go.dev/src/runtime/map_fast32_noswiss.go
- For materializer values iterator, skip more aggressively. Today we only skip to next row if there is no value page but only dictionary page. We can also skip `Next` when there is value pages also to reduce number of `Next` calls, especially when rows are sparese

### Benchmark results

Can see some small improvements on CPU time for certain queries.

```
benchstat old new
goos: linux
goarch: amd64
pkg: github.com/prometheus-community/parquet-common/queryable
cpu: Intel(R) Xeon(R) Platinum 8124M CPU @ 3.00GHz
                                        │     old      │                new                 │
                                        │    sec/op    │   sec/op     vs base               │
Select/SingleMetricAllSeries-16           642.7m ± 11%   641.9m ± 8%        ~ (p=0.699 n=6)
Select/SingleMetricReducedSeries-16       22.59m ± 19%   21.59m ± 1%   -4.40% (p=0.009 n=6)
Select/SingleMetricOneSeries-16           19.48m ± 14%   18.16m ± 2%   -6.74% (p=0.026 n=6)
Select/SingleMetricSparseSeries-16        51.16m ± 10%   45.75m ± 1%  -10.57% (p=0.015 n=6)
Select/NonExistentSeries-16               20.44m ±  9%   17.23m ± 1%  -15.69% (p=0.002 n=6)
Select/MultipleMetricsRange-16             2.774 ± 13%    2.760 ± 3%        ~ (p=0.589 n=6)
Select/MultipleMetricsSparse-16           728.0m ±  4%   725.5m ± 3%        ~ (p=0.394 n=6)
Select/NegativeRegexSingleMetric-16       514.1m ±  1%   506.7m ± 4%        ~ (p=0.394 n=6)
Select/NegativeRegexMultipleMetrics-16     1.680 ±  1%    1.689 ± 1%        ~ (p=0.310 n=6)
Select/ExpensiveRegexSingleMetric-16      63.05m ±  6%   58.16m ± 1%   -7.75% (p=0.002 n=6)
Select/ExpensiveRegexMultipleMetrics-16   156.0m ±  4%   150.2m ± 1%   -3.73% (p=0.002 n=6)
geomean                                   176.2m         167.8m        -4.75%

                                        │        old         │                    new                     │
                                        │ bytes_get_range/op │ bytes_get_range/op  vs base                │
Select/SingleMetricAllSeries-16                  5.684M ± 0%          5.684M ± 0%  -0.00% (p=0.002 n=6)
Select/SingleMetricReducedSeries-16              327.5k ± 0%          327.5k ± 0%  -0.00% (p=0.002 n=6)
Select/SingleMetricOneSeries-16                  280.5k ± 0%          280.5k ± 0%       ~ (p=1.000 n=6) ¹
Select/SingleMetricSparseSeries-16               1.982M ± 0%          1.982M ± 0%  -0.00% (p=0.002 n=6)
Select/NonExistentSeries-16                      270.6k ± 0%          270.6k ± 0%       ~ (p=1.000 n=6) ¹
Select/MultipleMetricsRange-16                   30.87M ± 0%          30.87M ± 0%  -0.00% (p=0.002 n=6)
Select/MultipleMetricsSparse-16                  14.63M ± 0%          14.63M ± 0%  -0.00% (p=0.002 n=6)
Select/NegativeRegexSingleMetric-16              6.334M ± 0%          6.334M ± 0%  -0.00% (p=0.002 n=6)
Select/NegativeRegexMultipleMetrics-16           27.40M ± 0%          27.40M ± 0%  -0.00% (p=0.002 n=6)
Select/ExpensiveRegexSingleMetric-16             2.220M ± 0%          2.220M ± 0%  -0.00% (p=0.002 n=6)
Select/ExpensiveRegexMultipleMetrics-16          14.74M ± 0%          14.74M ± 0%       ~ (p=1.000 n=6) ¹
geomean                                          3.407M               3.407M       -0.00%
¹ all samples are equal

                                        │     old      │                new                 │
                                        │    get/op    │   get/op    vs base                │
Select/SingleMetricAllSeries-16           0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=6) ¹
Select/SingleMetricReducedSeries-16       0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=6) ¹
Select/SingleMetricOneSeries-16           0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=6) ¹
Select/SingleMetricSparseSeries-16        0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=6) ¹
Select/NonExistentSeries-16               0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=6) ¹
Select/MultipleMetricsRange-16            0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=6) ¹
Select/MultipleMetricsSparse-16           0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=6) ¹
Select/NegativeRegexSingleMetric-16       0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=6) ¹
Select/NegativeRegexMultipleMetrics-16    0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=6) ¹
Select/ExpensiveRegexSingleMetric-16      0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=6) ¹
Select/ExpensiveRegexMultipleMetrics-16   0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=6) ¹
geomean                                              ²               +0.00%               ²
¹ all samples are equal
² summaries must be >0 to compute geomean

                                        │     old      │                 new                  │
                                        │ get_range/op │ get_range/op  vs base                │
Select/SingleMetricAllSeries-16            5.400k ± 0%    5.400k ± 0%       ~ (p=1.000 n=6) ¹
Select/SingleMetricReducedSeries-16         654.0 ± 0%     654.0 ± 0%       ~ (p=1.000 n=6) ¹
Select/SingleMetricOneSeries-16             624.0 ± 0%     624.0 ± 0%       ~ (p=1.000 n=6) ¹
Select/SingleMetricSparseSeries-16         3.000k ± 0%    3.000k ± 0%       ~ (p=1.000 n=6) ¹
Select/NonExistentSeries-16                 600.0 ± 0%     600.0 ± 0%       ~ (p=1.000 n=6) ¹
Select/MultipleMetricsRange-16             58.01k ± 0%    58.01k ± 0%       ~ (p=1.000 n=6) ¹
Select/MultipleMetricsSparse-16            43.61k ± 0%    43.61k ± 0%       ~ (p=1.000 n=6) ¹
Select/NegativeRegexSingleMetric-16        12.11k ± 0%    12.11k ± 0%       ~ (p=1.000 n=6) ¹
Select/NegativeRegexMultipleMetrics-16     73.33k ± 0%    73.33k ± 0%       ~ (p=1.000 n=6) ¹
Select/ExpensiveRegexSingleMetric-16       8.459k ± 0%    8.459k ± 0%       ~ (p=1.000 n=6) ¹
Select/ExpensiveRegexMultipleMetrics-16    62.10k ± 0%    62.10k ± 0%       ~ (p=1.000 n=6) ¹
geomean                                    7.570k         7.570k       +0.00%
¹ all samples are equal

                                        │      old      │                 new                 │
                                        │   series/op   │  series/op   vs base                │
Select/SingleMetricAllSeries-16           300.0k ± 0%     300.0k ± 0%       ~ (p=1.000 n=6) ¹
Select/SingleMetricReducedSeries-16       3.000k ± 0%     3.000k ± 0%       ~ (p=1.000 n=6) ¹
Select/SingleMetricOneSeries-16            1.000 ± 0%      1.000 ± 0%       ~ (p=1.000 n=6) ¹
Select/SingleMetricSparseSeries-16        5.000k ± 0%     5.000k ± 0%       ~ (p=1.000 n=6) ¹
Select/NonExistentSeries-16                0.000 ± 0%      0.000 ± 0%       ~ (p=1.000 n=6) ¹
Select/MultipleMetricsRange-16            1.200M ± 0%     1.200M ± 0%       ~ (p=1.000 n=6) ¹
Select/MultipleMetricsSparse-16           300.0k ± 0%     300.0k ± 0%       ~ (p=1.000 n=6) ¹
Select/NegativeRegexSingleMetric-16       234.0k ± 0%     234.0k ± 0%       ~ (p=1.000 n=6) ¹
Select/NegativeRegexMultipleMetrics-16    702.0k ± 0%     702.0k ± 0%       ~ (p=1.000 n=6) ¹
Select/ExpensiveRegexSingleMetric-16      6.000k ± 0%     6.000k ± 0%       ~ (p=1.000 n=6) ¹
Select/ExpensiveRegexMultipleMetrics-16    0.000 ± 0%      0.000 ± 0%       ~ (p=1.000 n=6) ¹
geomean                                               ²                +0.00%               ²
¹ all samples are equal
² summaries must be >0 to compute geomean

                                        │     old      │                new                 │
                                        │     B/op     │     B/op      vs base              │
Select/SingleMetricAllSeries-16           781.7Mi ± 0%   780.2Mi ± 0%  -0.20% (p=0.002 n=6)
Select/SingleMetricReducedSeries-16       70.56Mi ± 0%   70.32Mi ± 0%  -0.34% (p=0.002 n=6)
Select/SingleMetricOneSeries-16           65.82Mi ± 0%   65.59Mi ± 0%  -0.34% (p=0.002 n=6)
Select/SingleMetricSparseSeries-16        131.3Mi ± 0%   130.6Mi ± 0%  -0.52% (p=0.002 n=6)
Select/NonExistentSeries-16               62.91Mi ± 0%   62.69Mi ± 0%  -0.35% (p=0.002 n=6)
Select/MultipleMetricsRange-16            3.129Gi ± 0%   3.122Gi ± 0%  -0.21% (p=0.002 n=6)
Select/MultipleMetricsSparse-16           1.037Gi ± 0%   1.034Gi ± 0%  -0.27% (p=0.002 n=6)
Select/NegativeRegexSingleMetric-16       719.2Mi ± 0%   717.7Mi ± 0%  -0.21% (p=0.002 n=6)
Select/NegativeRegexMultipleMetrics-16    2.180Gi ± 0%   2.174Gi ± 0%  -0.25% (p=0.002 n=6)
Select/ExpensiveRegexSingleMetric-16      191.4Mi ± 0%   190.9Mi ± 0%  -0.27% (p=0.002 n=6)
Select/ExpensiveRegexMultipleMetrics-16   536.7Mi ± 0%   534.3Mi ± 0%  -0.45% (p=0.002 n=6)
geomean                                   368.1Mi        367.0Mi       -0.31%

                                        │     old     │                new                │
                                        │  allocs/op  │  allocs/op   vs base              │
Select/SingleMetricAllSeries-16           7.972M ± 0%   7.969M ± 0%  -0.04% (p=0.002 n=6)
Select/SingleMetricReducedSeries-16       230.4k ± 0%   229.9k ± 0%  -0.22% (p=0.002 n=6)
Select/SingleMetricOneSeries-16           225.2k ± 0%   224.8k ± 0%  -0.21% (p=0.002 n=6)
Select/SingleMetricSparseSeries-16        565.6k ± 0%   564.1k ± 0%  -0.27% (p=0.002 n=6)
Select/NonExistentSeries-16               150.9k ± 0%   150.5k ± 0%  -0.31% (p=0.002 n=6)
Select/MultipleMetricsRange-16            32.37M ± 0%   32.36M ± 0%  -0.04% (p=0.002 n=6)
Select/MultipleMetricsSparse-16           8.986M ± 0%   8.981M ± 0%  -0.06% (p=0.002 n=6)
Select/NegativeRegexSingleMetric-16       6.884M ± 0%   6.881M ± 0%  -0.05% (p=0.002 n=6)
Select/NegativeRegexMultipleMetrics-16    20.21M ± 0%   20.20M ± 0%  -0.05% (p=0.002 n=6)
Select/ExpensiveRegexSingleMetric-16      840.1k ± 0%   839.1k ± 0%  -0.12% (p=0.002 n=6)
Select/ExpensiveRegexMultipleMetrics-16   1.796M ± 0%   1.792M ± 0%  -0.21% (p=0.002 n=6)
geomean                                   2.009M        2.006M       -0.14%
```