### PR TITLE
re-add optimizations when querying sparse data

### DIFF
--- a/search/iterators.go
+++ b/search/iterators.go
@@ -530,6 +530,9 @@ func (i *RowRangesValueIterator) Next() bool {
 					i.remainingRr = i.remainingRr[1:]
 				}
 			}
+			if i.pageIterator.CanSkip() && i.remaining > 0 {
+				i.currentRow += i.pageIterator.Skip(i.next - i.currentRow - 1)
+			}
 			i.currentRow++
 		}
 		parquet.Release(page)
@@ -599,6 +602,16 @@ func (i *PageValueIterator) Next() bool {
 	}
 
 	return true
+}
+
+func (i *PageValueIterator) CanSkip() bool {
+	return i.vr == nil
+}
+
+func (i *PageValueIterator) Skip(n int64) int64 {
+	r := min(n, i.p.NumRows()-int64(i.current)-1)
+	i.current += int(r)
+	return r
 }
 
 func (i *PageValueIterator) Reset(p parquet.Page) {


### PR DESCRIPTION
These changes from https://github.com/prometheus-community/parquet-common/pull/94 got clobbered on some rebase/merge difficulties on the chunks iterators PR - adding back in.

I reduced the `BenchmarkSelect` series on my machine from 1000 to 100 so it wasn't dominated by GC, and the results look good and expected:

```
[~/repos/parquet-common] % benchstat benchout-queryable-3e93776-no-skip.txt benchout-queryable-WIP-re-add-skip.txt
goos: linux
goarch: amd64
pkg: github.com/prometheus-community/parquet-common/queryable
cpu: AMD Ryzen 9 PRO 6950H with Radeon Graphics
                                        │ benchout-queryable-3e93776-no-skip.txt │ benchout-queryable-WIP-re-add-skip.txt │
                                        │                 sec/op                 │     sec/op      vs base                │
Select/SingleMetricAllSeries-16                                     20.00m ±  2%     21.19m ± 14%   +5.94% (p=0.002 n=10)
Select/SingleMetricReducedSeries-16                                 787.1µ ±  9%     803.9µ ±  9%        ~ (p=0.912 n=10)
Select/SingleMetricOneSeries-16                                     564.5µ ± 14%     539.6µ ±  6%   -4.41% (p=0.009 n=10)
Select/SingleMetricSparseSeries-16                                  3.863m ± 14%     3.430m ± 11%  -11.22% (p=0.015 n=10)
Select/NonExistentSeries-16                                         579.2µ ± 13%     539.1µ ±  9%        ~ (p=0.165 n=10)
Select/MultipleMetricsRange-16                                      91.95m ± 10%     83.70m ±  6%        ~ (p=0.063 n=10)
Select/MultipleMetricsSparse-16                                     29.16m ±  3%     26.52m ±  9%   -9.03% (p=0.009 n=10)
Select/NegativeRegexSingleMetric-16                                 20.15m ± 11%     21.05m ± 14%        ~ (p=0.436 n=10)
Select/NegativeRegexMultipleMetrics-16                              55.24m ±  5%     55.54m ±  4%        ~ (p=0.529 n=10)
Select/ExpensiveRegexSingleMetric-16                                3.426m ± 13%     3.358m ±  7%        ~ (p=0.579 n=10)
Select/ExpensiveRegexMultipleMetrics-16                             7.919m ±  5%     8.222m ±  5%        ~ (p=0.123 n=10)
geomean                                                             6.870m           6.698m         -2.50%
```
