### PR TITLE
chore(converter): scope postings to series with chunks in interval

### DIFF
--- a/convert/convert.go
+++ b/convert/convert.go
@@ -29,6 +29,7 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/tsdb"
+	"github.com/prometheus/prometheus/tsdb/chunks"
 	"github.com/prometheus/prometheus/tsdb/index"
 	"github.com/prometheus/prometheus/tsdb/tombstones"
 	"github.com/thanos-io/objstore"
@@ -400,7 +401,7 @@ func NewTsdbRowReader(ctx context.Context, mint, maxt, colDuration int64, blks [
 			return nil, fmt.Errorf("unable to get label names from block: %w", err)
 		}
 
-		postings := sortedPostings(ctx, indexr, ops.sortedLabels...)
+		postings := sortedPostings(ctx, indexr, mint, maxt, ops.sortedLabels...)
 		seriesSet := tsdb.NewBlockChunkSeriesSet(blk.Meta().ULID, indexr, chunkr, tombsr, postings, mint, maxt, false)
 		seriesSets = append(seriesSets, seriesSet)
 
@@ -438,7 +439,7 @@ func (rr *TsdbRowReader) Schema() *schema.TSDBSchema {
 	return rr.tsdbSchema
 }
 
-func sortedPostings(ctx context.Context, indexr tsdb.IndexReader, sortedLabels ...string) index.Postings {
+func sortedPostings(ctx context.Context, indexr tsdb.IndexReader, mint, maxt int64, sortedLabels ...string) index.Postings {
 	p := tsdb.AllSortedPostings(ctx, indexr)
 
 	if len(sortedLabels) == 0 {
@@ -451,16 +452,25 @@ func sortedPostings(ctx context.Context, indexr tsdb.IndexReader, sortedLabels .
 		labels labels.Labels
 	}
 	series := make([]s, 0, 128)
+	chks := make([]chunks.Meta, 0, 128)
 
 	scratchBuilder := labels.NewScratchBuilder(10)
 	lb := labels.NewBuilder(labels.EmptyLabels())
 	i := 0
+P:
 	for p.Next() {
 		scratchBuilder.Reset()
-		err := indexr.Series(p.At(), &scratchBuilder, nil)
-		if err != nil {
-			return index.ErrPostings(fmt.Errorf("expand series: %w", err))
+		chks = chks[:0]
+		if err := indexr.Series(p.At(), &scratchBuilder, &chks); err != nil {
+			return index.ErrPostings(fmt.Errorf("unable to expand series: %w", err))
 		}
+		hasChunks := slices.ContainsFunc(chks, func(chk chunks.Meta) bool {
+			return mint <= chk.MaxTime && chk.MinTime <= maxt
+		})
+		if !hasChunks {
+			continue P
+		}
+
 		lb.Reset(scratchBuilder.Labels())
 
 		series = append(series, s{labels: lb.Keep(sortedLabels...).Labels(), ref: p.At(), idx: i})


### PR DESCRIPTION
If we happen to converter a one day block out of a 14 day TSDB block we could run into a situation where we decode and iterate over series that we know dont have chunks in the particular day we are interested in, i.e. because of churn.
This change makes it so we just skip those series without looking at any chunks.