### PR TITLE
skip wildcard .* regex matcher

### DIFF
--- a/search/constraint.go
+++ b/search/constraint.go
@@ -54,6 +54,9 @@ func MatchersToConstraints(matchers ...*labels.Matcher) ([]Constraint, error) {
 		case labels.MatchNotEqual:
 			c = Not(Equal(schema.LabelToColumn(matcher.Name), parquet.ValueOf(matcher.Value)))
 		case labels.MatchRegexp:
+			if matcher.GetRegexString() == ".*" {
+				continue
+			}
 			if matcher.GetRegexString() == ".+" {
 				c = Not(Equal(schema.LabelToColumn(matcher.Name), parquet.ValueOf("")))
 				break S

--- a/search/constraint_test.go
+++ b/search/constraint_test.go
@@ -273,6 +273,14 @@ func TestFilter(t *testing.T) {
 							{From: 2, Count: 2},
 						},
 					},
+					{
+						constraints: []Constraint{
+							mustRegexConstraint(t, "C", mustNewMatcher(t, ".*")),
+						},
+						expect: []RowRange{
+							{From: 0, Count: 8},
+						},
+					},
 				},
 			},
 			{


### PR DESCRIPTION
Follow up of https://github.com/prometheus-community/parquet-common/pull/101 to just skip `.*` regex matcher.

