### PR TITLE
don't include series hash when no labels to exclude in projection hints

### DIFF
--- a/search/materialize.go
+++ b/search/materialize.go
@@ -467,7 +467,8 @@ func (m *Materializer) MaterializeLabels(ctx context.Context, hints *prom_storag
 				break
 			}
 		}
-		needsHash = !seriesHashExcluded
+		// Hash column is only needed if projection labels are provided and series hash is not excluded.
+		needsHash = !seriesHashExcluded && len(hints.ProjectionLabels) > 0
 
 		for _, labelName := range hints.ProjectionLabels {
 			if labelName == schema.SeriesHashColumn {


### PR DESCRIPTION
By default, when no projection the projection hints will be projection include set to false and no projection labels. This should fetch all labels which is the same as no projection.

However, the implementation today will fetch all labels + hash column on the default case. This is totally unnecessary as series hash should be only fetched when we skip fetching certain labels due to projection. But the default case, we still fetch all label columns then there is no need to fetch the hash column.

This PR adds a check to only fetch hash when there is at least 1 projection label to exclude.