### PR TITLE
Shard parquet files based on configured number of columns limit

### DIFF
--- a/convert/convert.go
+++ b/convert/convert.go
@@ -39,6 +39,9 @@ import (
 	"github.com/prometheus-community/parquet-common/schema"
 )
 
+// 2 system columns: s_col_indexes and s_series_hash
+const systemColumns = 2
+
 var DefaultConvertOpts = convertOpts{
 	name:               "block",
 	rowGroupSize:       1e6,
@@ -52,6 +55,7 @@ var DefaultConvertOpts = convertOpts{
 	readConcurrency:    runtime.GOMAXPROCS(0),
 	writeConcurrency:   1,
 	maxSamplesPerChunk: tsdb.DefaultSamplesPerChunk,
+	maxNumColumns:      parquet.MaxColumnIndex, // 32767 - max column index supported by parquet-go
 }
 
 type Convertible interface {
@@ -74,6 +78,7 @@ type convertOpts struct {
 	readConcurrency       int
 	writeConcurrency      int
 	maxSamplesPerChunk    int
+	maxNumColumns         int
 	labelsCompressionOpts []schema.CompressionOpts
 	chunksCompressionOpts []schema.CompressionOpts
 }
@@ -277,6 +282,27 @@ func WithMaxSamplesPerChunk(samplesPerChunk int) ConvertOption {
 	}
 }
 
+// WithMaxNumColumns sets the maximum number of columns allowed in a Parquet file.
+// Parquet has a limit of approximately 32767 columns (MaxInt16). When this limit is exceeded,
+// the conversion will automatically shard the data into multiple files. This option allows
+// users to control the number of columns in the converted parquet file.
+//
+// The limit includes both label columns (one per unique label name) and 2 system columns
+// (s_col_indexes and s_series_hash). For example, if maxColumns is 1000, then at most
+// 998 unique label names can be included in a single shard.
+//
+// Parameters:
+//   - maxColumns: Maximum number of columns per Parquet file, including system columns (default: 32767)
+//
+// Example:
+//
+//	WithMaxNumColumns(1000)  // Use a smaller limit for testing
+func WithMaxNumColumns(maxColumns int) ConvertOption {
+	return func(opts *convertOpts) {
+		opts.maxNumColumns = maxColumns
+	}
+}
+
 func WithColumnPageBuffers(buffers parquet.BufferPool) ConvertOption {
 	return func(opts *convertOpts) {
 		opts.columnPageBuffers = buffers
@@ -359,17 +385,16 @@ func ConvertTSDBBlock(
 	}
 
 	var (
-		rr                *TSDBRowReader
 		shardedRowReaders []*TSDBRowReader
 		err               error
 	)
 	// If numRowGroups is not specified, we can use a single row reader.
+	// However, we may still need to shard if column limits are exceeded.
 	if cfg.numRowGroups == math.MaxInt32 {
-		rr, err = singleTSDBRowReader(ctx, mint, maxt, cfg.colDuration.Milliseconds(), blocks, cfg)
+		shardedRowReaders, err = singleTSDBRowReader(ctx, mint, maxt, cfg.colDuration.Milliseconds(), blocks, cfg)
 		if err != nil {
 			return 0, errors.Wrap(err, "failed to create TSDB row readers")
 		}
-		shardedRowReaders = []*TSDBRowReader{rr}
 	} else {
 		logger.Info("sharding input series")
 		shardedRowReaders, err = shardedTSDBRowReaders(ctx, mint, maxt, cfg.colDuration.Milliseconds(), blocks, cfg)
@@ -439,21 +464,75 @@ type blockSeries struct {
 	labels    labels.Labels
 }
 
-// singleTSDBRowReader is a shortcut when we know there is only one final shard.
-// This can happen when numRowGroups is not specified.
+// singleTSDBRowReader creates row readers when numRowGroups is not specified.
+// It may create multiple shards if the column limit would be exceeded.
 func singleTSDBRowReader(
 	ctx context.Context,
 	mint, maxt, colDuration int64,
 	blocks []Convertible,
 	opts convertOpts,
-) (*TSDBRowReader, error) {
+) ([]*TSDBRowReader, error) {
+	// First, check if we need to shard based on column limits by getting all unique label names.
+	// This is cheaper than fully initializing indexReaders and postings, so we do this first.
+	allLabelNames := make(map[string]struct{})
+	for _, blk := range blocks {
+		indexr, err := blk.Index()
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to get label names from index reader")
+		}
+		lblns, err := indexr.LabelNames(ctx)
+		if err != nil {
+			_ = indexr.Close()
+			return nil, errors.Wrap(err, "failed to get label names from index reader")
+		}
+		for _, lbln := range lblns {
+			allLabelNames[lbln] = struct{}{}
+		}
+		_ = indexr.Close()
+	}
+
+	// If total unique label names exceed the limit, we need to shard based only on column limits.
+	if len(allLabelNames)+systemColumns >= opts.maxNumColumns {
+		indexReaders := make([]blockIndexReader, len(blocks))
+		defer func() {
+			for _, indexReader := range indexReaders {
+				if indexReader.reader != nil {
+					_ = indexReader.reader.Close()
+				}
+			}
+		}()
+		for i, blk := range blocks {
+			indexReader, err := blk.Index()
+			if err != nil {
+				return nil, errors.Wrap(err, "failed to get index reader from block")
+			}
+			indexReaders[i] = blockIndexReader{
+				blockID:  blk.Meta().ULID,
+				idx:      i,
+				reader:   indexReader,
+				postings: tsdb.AllSortedPostings(ctx, indexReader),
+			}
+		}
+
+		// Use shardSeries to shard based only on column limits (no row group limits).
+		uniqueSeriesCount, shardedSeries, err := shardSeries(indexReaders, mint, maxt, opts)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to determine unique series count")
+		}
+		if uniqueSeriesCount == 0 {
+			return nil, errors.New("no series found in the specified time range")
+		}
+
+		// Create row readers from sharded series (same logic as shardedTSDBRowReaders).
+		return createShardedRowReaders(ctx, mint, maxt, colDuration, blocks, shardedSeries, opts)
+	}
+
+	// No sharding needed - create a single row reader (original behavior)
 	var (
 		seriesSets = make([]storage.ChunkSeriesSet, 0, len(blocks))
 		closers    = make([]io.Closer, 0, len(blocks))
 		ok         = false
 	)
-	// If we fail to build the row reader, make sure we release resources.
-	// This could be either a controlled error or a panic.
 	defer func() {
 		if !ok {
 			for i := range closers {
@@ -470,7 +549,6 @@ func singleTSDBRowReader(
 				return c
 			}
 		}
-
 		return labels.Compare(a, b)
 	}
 
@@ -510,45 +588,18 @@ func singleTSDBRowReader(
 		return nil, fmt.Errorf("unable to build schema reader from block: %w", err)
 	}
 	ok = true
-	return newTSDBRowReader(ctx, closers, cseriesSet, s, opts), nil
+	return []*TSDBRowReader{newTSDBRowReader(ctx, closers, cseriesSet, s, opts)}, nil
 }
 
-func shardedTSDBRowReaders(
+// createShardedRowReaders creates TSDBRowReader instances from sharded series.
+// This is a shared helper used by both singleTSDBRowReader and shardedTSDBRowReaders.
+func createShardedRowReaders(
 	ctx context.Context,
 	mint, maxt, colDuration int64,
 	blocks []Convertible,
+	shardedSeries []map[int][]blockSeries,
 	opts convertOpts,
 ) ([]*TSDBRowReader, error) {
-	// Blocks can have multiple entries with the same of ULID in the case of head blocks;
-	// track all blocks by their index in the input slice rather than assuming unique ULIDs.
-	indexReaders := make([]blockIndexReader, len(blocks))
-	// Simpler to track and close these readers separate from those used by shard conversion reader/writers.
-	defer func() {
-		for _, indexReader := range indexReaders {
-			_ = indexReader.reader.Close()
-		}
-	}()
-	for i, blk := range blocks {
-		indexReader, err := blk.Index()
-		if err != nil {
-			return nil, errors.Wrap(err, "failed to get index reader from block")
-		}
-		indexReaders[i] = blockIndexReader{
-			blockID:  blk.Meta().ULID,
-			idx:      i,
-			reader:   indexReader,
-			postings: tsdb.AllSortedPostings(ctx, indexReader),
-		}
-	}
-
-	uniqueSeriesCount, shardedSeries, err := shardSeries(indexReaders, mint, maxt, opts)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to determine unique series count")
-	}
-	if uniqueSeriesCount == 0 {
-		return nil, errors.Wrap(err, "no series found in the specified time range")
-	}
-
 	shardTSDBRowReaders := make([]*TSDBRowReader, len(shardedSeries))
 
 	// We close everything if any errors or panic occur
@@ -579,7 +630,7 @@ func shardedTSDBRowReaders(
 			blk := blocks[blockSeries[0].blockIdx]
 			// Init all readers for block & add to closers
 
-			// Init separate index readers from above indexReaders to simplify closing logic
+			// Init separate index readers to simplify closing logic
 			indexr, err := blk.Index()
 			if err != nil {
 				return nil, errors.Wrap(err, "failed to get index reader from block")
@@ -628,6 +679,45 @@ func shardedTSDBRowReaders(
 	}
 	ok = true
 	return shardTSDBRowReaders, nil
+}
+
+func shardedTSDBRowReaders(
+	ctx context.Context,
+	mint, maxt, colDuration int64,
+	blocks []Convertible,
+	opts convertOpts,
+) ([]*TSDBRowReader, error) {
+	// Blocks can have multiple entries with the same of ULID in the case of head blocks;
+	// track all blocks by their index in the input slice rather than assuming unique ULIDs.
+	indexReaders := make([]blockIndexReader, len(blocks))
+	// Simpler to track and close these readers separate from those used by shard conversion reader/writers.
+	defer func() {
+		for _, indexReader := range indexReaders {
+			_ = indexReader.reader.Close()
+		}
+	}()
+	for i, blk := range blocks {
+		indexReader, err := blk.Index()
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to get index reader from block")
+		}
+		indexReaders[i] = blockIndexReader{
+			blockID:  blk.Meta().ULID,
+			idx:      i,
+			reader:   indexReader,
+			postings: tsdb.AllSortedPostings(ctx, indexReader),
+		}
+	}
+
+	uniqueSeriesCount, shardedSeries, err := shardSeries(indexReaders, mint, maxt, opts)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to determine unique series count")
+	}
+	if uniqueSeriesCount == 0 {
+		return nil, errors.Wrap(err, "no series found in the specified time range")
+	}
+
+	return createShardedRowReaders(ctx, mint, maxt, colDuration, blocks, shardedSeries, opts)
 }
 
 func shardSeries(
@@ -681,50 +771,75 @@ func shardSeries(
 		}
 	}
 
-	// Divide rows evenly across shards to avoid one small shard at the end;
-	// Use (a + b - 1) / b equivalence to math.Ceil(a / b)
-	// so integer division does not cut off the remainder series and to avoid floating point issues.
-	totalShards := (uniqueSeriesCount + (opts.numRowGroups * opts.rowGroupSize) - 1) / (opts.numRowGroups * opts.rowGroupSize)
-	rowsPerShard := (uniqueSeriesCount + totalShards - 1) / totalShards
-
-	// For each shard index i, shardSeries[i] is a map of blockIdx -> []series.
-	shardSeries := make([]map[int][]blockSeries, totalShards)
-	for i := range shardSeries {
-		shardSeries[i] = make(map[int][]blockSeries)
+	// Calculate row-based sharding only if numRowGroups is set (not MaxInt32)
+	var targetTotalShards int
+	var rowsPerShard int
+	if opts.numRowGroups != math.MaxInt32 {
+		// Divide rows evenly across shards to avoid one small shard at the end;
+		// Use (a + b - 1) / b equivalence to math.Ceil(a / b)
+		// so integer division does not cut off the remainder series and to avoid floating point issues.
+		targetTotalShards = (uniqueSeriesCount + (opts.numRowGroups * opts.rowGroupSize) - 1) / (opts.numRowGroups * opts.rowGroupSize)
+		rowsPerShard = (uniqueSeriesCount + targetTotalShards - 1) / targetTotalShards
 	}
 
-	shardIdx, allSeriesIdx := 0, 0
-	for shardIdx < totalShards {
-		seriesToShard := allSeries[allSeriesIdx:]
+	// For each shard index i, shardSeries[i] is a map of blockIdx -> []series.
+	// Start with one shard and dynamically create more as needed to avoid column limit.
+	// If row-based sharding is enabled, pre-allocate capacity for expected shards.
+	initialCapacity := 1
+	if opts.numRowGroups != math.MaxInt32 && targetTotalShards > 1 {
+		initialCapacity = targetTotalShards
+	}
+	shardSeries := make([]map[int][]blockSeries, 1, initialCapacity)
+	shardSeries[0] = make(map[int][]blockSeries)
 
-		i, uniqueCount := 0, 0
-		matchLabels := labels.Labels{}
-		for i < len(seriesToShard) {
-			current := seriesToShard[i]
-			if labels.Compare(current.labels, matchLabels) != 0 {
-				// New unique series
-
-				if uniqueCount >= rowsPerShard {
-					// Stop before adding current series if it would exceed the unique series count for the shard.
-					// Do not increment, we will start the next shard with this series.
-					break
+	shardIdx, uniqueCount := 0, 0
+	matchLabels := labels.Labels{}
+	labelColumns := make(map[string]struct{})
+	for _, series := range allSeries {
+		if labels.Compare(series.labels, matchLabels) != 0 {
+			// New unique series
+			// Count how many new label names this series would add
+			newLabelCount := 0
+			series.labels.Range(func(label labels.Label) {
+				if _, exists := labelColumns[label.Name]; !exists {
+					newLabelCount++
 				}
+			})
 
-				// Unique series limit is not hit yet for the shard; add the series.
-				shardSeries[shardIdx][current.blockIdx] = append(shardSeries[shardIdx][current.blockIdx], current)
-				// Increment unique count, update labels to compare against, and move on to next series
-				uniqueCount++
-				matchLabels = current.labels
-				i++
-			} else {
-				// Same labelset as previous series, add it to the shard but do not increment unique count
-				shardSeries[shardIdx][current.blockIdx] = append(shardSeries[shardIdx][current.blockIdx], current)
-				// Move on to next series
-				i++
+			// Create a new shard if:
+			// 1. Row-based sharding is enabled AND the row limit is reached, OR
+			// 2. Adding this series would exceed the column limit
+			shouldCreateNewShard := false
+			if opts.numRowGroups != math.MaxInt32 && uniqueCount >= rowsPerShard {
+				shouldCreateNewShard = true
 			}
-			allSeriesIdx++
+			if len(labelColumns)+newLabelCount+systemColumns >= opts.maxNumColumns {
+				shouldCreateNewShard = true
+			}
+
+			if shouldCreateNewShard {
+				// Create a new shard and start with this series
+				shardIdx++
+				shardSeries = append(shardSeries, make(map[int][]blockSeries))
+				labelColumns = make(map[string]struct{})
+				uniqueCount = 0
+			}
+
+			// Track unique label names for this shard (after potentially creating a new shard)
+			series.labels.Range(func(label labels.Label) {
+				labelColumns[label.Name] = struct{}{}
+			})
+
+			// Unique series limit is not hit yet for the shard; add the series.
+			shardSeries[shardIdx][series.blockIdx] = append(shardSeries[shardIdx][series.blockIdx], series)
+			// Increment unique count, update labels to compare against, and move on to next series
+			uniqueCount++
+			matchLabels = series.labels
+		} else {
+			// Same labelset as previous series, add it to the shard but do not increment unique count
+			shardSeries[shardIdx][series.blockIdx] = append(shardSeries[shardIdx][series.blockIdx], series)
+			// Move on to next series
 		}
-		shardIdx++
 	}
 
 	return uniqueSeriesCount, shardSeries, nil

--- a/convert/convert.go
+++ b/convert/convert.go
@@ -55,7 +55,7 @@ var DefaultConvertOpts = convertOpts{
 	readConcurrency:    runtime.GOMAXPROCS(0),
 	writeConcurrency:   1,
 	maxSamplesPerChunk: tsdb.DefaultSamplesPerChunk,
-	maxNumColumns:      parquet.MaxColumnIndex, // 32767 - max column index supported by parquet-go
+	maxNumColumns:      parquet.MaxColumnIndex, // max column index supported by parquet-go
 }
 
 type Convertible interface {
@@ -283,7 +283,7 @@ func WithMaxSamplesPerChunk(samplesPerChunk int) ConvertOption {
 }
 
 // WithMaxNumColumns sets the maximum number of columns allowed in a Parquet file.
-// Parquet has a limit of approximately 32767 columns (MaxInt16). When this limit is exceeded,
+// Parquet-go library has a limit of max column index supported. When this limit is exceeded,
 // the conversion will automatically shard the data into multiple files. This option allows
 // users to control the number of columns in the converted parquet file.
 //
@@ -292,7 +292,7 @@ func WithMaxSamplesPerChunk(samplesPerChunk int) ConvertOption {
 // 998 unique label names can be included in a single shard.
 //
 // Parameters:
-//   - maxColumns: Maximum number of columns per Parquet file, including system columns (default: 32767)
+//   - maxColumns: Maximum number of columns per Parquet file, including system columns
 //
 // Example:
 //
@@ -492,7 +492,8 @@ func singleTSDBRowReader(
 	}
 
 	// If total unique label names exceed the limit, we need to shard based only on column limits.
-	if len(allLabelNames)+systemColumns >= opts.maxNumColumns {
+	// Equality is allowed (exactly maxNumColumns columns is fine).
+	if len(allLabelNames)+systemColumns > opts.maxNumColumns {
 		indexReaders := make([]blockIndexReader, len(blocks))
 		defer func() {
 			for _, indexReader := range indexReaders {
@@ -808,12 +809,12 @@ func shardSeries(
 
 			// Create a new shard if:
 			// 1. Row-based sharding is enabled AND the row limit is reached, OR
-			// 2. Adding this series would exceed the column limit
+			// 2. Adding this series would exceed the column limit (equality is allowed)
 			shouldCreateNewShard := false
 			if opts.numRowGroups != math.MaxInt32 && uniqueCount >= rowsPerShard {
 				shouldCreateNewShard = true
 			}
-			if len(labelColumns)+newLabelCount+systemColumns >= opts.maxNumColumns {
+			if len(labelColumns)+newLabelCount+systemColumns > opts.maxNumColumns {
 				shouldCreateNewShard = true
 			}
 

--- a/convert/convert_test.go
+++ b/convert/convert_test.go
@@ -904,36 +904,36 @@ func Test_TooManyColumns(t *testing.T) {
 			name:             "with_numRowGroups_2_shards",
 			withNumRowGroups: true,
 			description:      "Uses shardedTSDBRowReaders path when numRowGroups is set, creates 2 shards",
-			maxNumColumns:    1000, // 998 label columns + 2 system columns
-			uniqueLabelNames: 1200, // Exceeds maxNumColumns to trigger sharding
-			labelsPerSeries:  200,  // Each series will have 200 unique labels (plus __name__)
+			maxNumColumns:    100, // 98 label columns + 2 system columns
+			uniqueLabelNames: 150, // Exceeds maxNumColumns to trigger sharding
+			labelsPerSeries:  50,  // Each series will have 50 unique labels (plus __name__)
 			minShards:        2,
 		},
 		{
 			name:             "without_numRowGroups_2_shards",
 			withNumRowGroups: false,
 			description:      "Uses singleTSDBRowReader path when numRowGroups is not set, creates 2 shards",
-			maxNumColumns:    1000, // 998 label columns + 2 system columns
-			uniqueLabelNames: 1200, // Exceeds maxNumColumns to trigger sharding
-			labelsPerSeries:  200,  // Each series will have 200 unique labels (plus __name__)
+			maxNumColumns:    100, // 98 label columns + 2 system columns
+			uniqueLabelNames: 150, // Exceeds maxNumColumns to trigger sharding
+			labelsPerSeries:  50,  // Each series will have 50 unique labels (plus __name__)
 			minShards:        2,
 		},
 		{
 			name:             "with_numRowGroups_3_shards",
 			withNumRowGroups: true,
 			description:      "Uses shardedTSDBRowReaders path when numRowGroups is set, creates 3+ shards",
-			maxNumColumns:    1000, // 998 label columns + 2 system columns
-			uniqueLabelNames: 2500, // Will require at least 3 shards (2500 / 998 ≈ 2.5)
-			labelsPerSeries:  300,  // Each series will have 300 unique labels (plus __name__)
+			maxNumColumns:    100, // 98 label columns + 2 system columns
+			uniqueLabelNames: 250, // Will require at least 3 shards (250 / 98 ≈ 2.55)
+			labelsPerSeries:  80,  // Each series will have 80 unique labels (plus __name__)
 			minShards:        3,
 		},
 		{
 			name:             "without_numRowGroups_3_shards",
 			withNumRowGroups: false,
 			description:      "Uses singleTSDBRowReader path when numRowGroups is not set, creates 3+ shards",
-			maxNumColumns:    1000, // 998 label columns + 2 system columns
-			uniqueLabelNames: 2500, // Will require at least 3 shards (2500 / 998 ≈ 2.5)
-			labelsPerSeries:  300,  // Each series will have 300 unique labels (plus __name__)
+			maxNumColumns:    100, // 98 label columns + 2 system columns
+			uniqueLabelNames: 250, // Will require at least 3 shards (250 / 98 ≈ 2.55)
+			labelsPerSeries:  80,  // Each series will have 80 unique labels (plus __name__)
 			minShards:        3,
 		},
 	}
@@ -1038,8 +1038,18 @@ func rowToSeries(t *testing.T, s *parquet.Schema, dec *schema.PrometheusParquetC
 			col := cols[colIdx][0]
 			label, ok := schema.ExtractLabelFromColumn(col)
 			if ok {
+				// Only include label columns that have actual values (not null/empty)
+				// This matches what's stored in s_col_indexes - only labels present in the series
+				if colVal.IsNull() {
+					continue
+				}
 				b.Add(label, colVal.String())
-				foundLblsIdxs = append(foundLblsIdxs, colIdx)
+				// Look up the ColumnIndex from the schema (same as when writing)
+				lc, ok := s.Lookup(col)
+				if !ok {
+					return nil, nil, fmt.Errorf("column %s not found in schema", col)
+				}
+				foundLblsIdxs = append(foundLblsIdxs, lc.ColumnIndex)
 			}
 
 			if schema.IsDataColumn(col) && dec != nil {

--- a/convert/convert_test.go
+++ b/convert/convert_test.go
@@ -802,6 +802,174 @@ func Test_TooManyColumnsPanic(t *testing.T) {
 	})
 }
 
+// createHighCardinalityTestData creates TSDB test data with high cardinality label names.
+// Each unique label name becomes a column in the Parquet file, plus system columns.
+// Returns the storage, head block pointer, and the number of unique label names created.
+// The caller is responsible for cleaning up the storage.
+func createHighCardinalityTestData(t *testing.T, uniqueLabelNames, labelsPerSeries int) (*teststorage.TestStorage, *tsdb.Head, int) {
+	ctx := context.Background()
+	st := teststorage.New(t)
+
+	app := st.Appender(ctx)
+	labelNameCounter := 0
+
+	// Create series with high cardinality label names
+	// Each series gets unique label names, ensuring we have many unique label names total
+	// We'll create enough series to exceed the column limit
+	numSeries := (uniqueLabelNames + labelsPerSeries - 1) / labelsPerSeries
+	for seriesIdx := 0; seriesIdx < numSeries && labelNameCounter < uniqueLabelNames; seriesIdx++ {
+		// Create labels for this series
+		seriesLabels := make([]string, 0, labelsPerSeries*2+2)
+		seriesLabels = append(seriesLabels, labels.MetricName, fmt.Sprintf("metric_%d", seriesIdx))
+
+		// Add unique label names to this series
+		for i := 0; i < labelsPerSeries && labelNameCounter < uniqueLabelNames; i++ {
+			labelName := fmt.Sprintf("high_cardinality_label_%d", labelNameCounter)
+			seriesLabels = append(seriesLabels, labelName, fmt.Sprintf("value_%d", seriesIdx))
+			labelNameCounter++
+		}
+
+		// Append a sample for this series
+		_, err := app.Append(0, labels.FromStrings(seriesLabels...), int64(seriesIdx), float64(seriesIdx))
+		require.NoError(t, err)
+
+		// Commit periodically to avoid memory issues
+		if seriesIdx%1000 == 0 && seriesIdx > 0 {
+			require.NoError(t, app.Commit())
+			app = st.Appender(ctx)
+		}
+	}
+
+	require.NoError(t, app.Commit())
+	require.GreaterOrEqual(t, labelNameCounter, uniqueLabelNames, "Should have created enough unique label names")
+	t.Logf("Created %d unique label names (target: %d)", labelNameCounter, uniqueLabelNames)
+
+	h := st.Head()
+
+	// Verify we actually have the unique label names in the TSDB block
+	indexr, err := h.Index()
+	require.NoError(t, err)
+	defer func() {
+		_ = indexr.Close()
+	}()
+	labelNames, err := indexr.LabelNames(ctx)
+	require.NoError(t, err)
+	// __name__ is always present, so we expect at least labelNameCounter + 1 unique label names
+	t.Logf("TSDB block has %d unique label names", len(labelNames))
+	require.GreaterOrEqual(t, len(labelNames), uniqueLabelNames, "TSDB block should have at least the expected number of unique label names")
+
+	return st, h, labelNameCounter
+}
+
+// verifyShardsWithLimit verifies that all shards are valid and don't exceed the specified column limit.
+func verifyShardsWithLimit(t *testing.T, ctx context.Context, bkt *filesystem.Bucket, shardCount int, maxNumColumns int) {
+	bucketOpener := storage.NewParquetBucketOpener(bkt)
+
+	for shardIdx := range shardCount {
+		shard, err := storage.NewParquetShardOpener(
+			ctx, DefaultConvertOpts.name, bucketOpener, bucketOpener, shardIdx,
+		)
+		require.NoError(t, err)
+
+		labelColumns := shard.LabelsFile().Schema().Columns()
+		totalColumns := len(labelColumns)
+
+		// Verify the shard doesn't exceed the column limit
+		require.LessOrEqual(t, totalColumns, maxNumColumns,
+			"Shard %d should not exceed Parquet column limit of %d", shardIdx, maxNumColumns)
+
+		// Verify we can read from the shard
+		series, chunks, err := readSeries(t, shard)
+		require.NoError(t, err)
+		require.NotEmpty(t, series, "Shard %d should contain series", shardIdx)
+		require.Equal(t, len(series), len(chunks), "Shard %d should have matching series and chunks", shardIdx)
+	}
+}
+
+// Test_TooManyColumns verifies that conversion correctly shards based on column limits
+// both when numRowGroups is set and when it's not.
+func Test_TooManyColumns(t *testing.T) {
+	ctx := context.Background()
+
+	tc := []struct {
+		name             string
+		withNumRowGroups bool
+		description      string
+		maxNumColumns    int // Maximum columns per shard (includes 2 system columns)
+		uniqueLabelNames int // Total unique label names to create
+		labelsPerSeries  int // Number of unique labels per series
+		minShards        int // Minimum expected number of shards
+	}{
+		{
+			name:             "with_numRowGroups_2_shards",
+			withNumRowGroups: true,
+			description:      "Uses shardedTSDBRowReaders path when numRowGroups is set, creates 2 shards",
+			maxNumColumns:    1000, // 998 label columns + 2 system columns
+			uniqueLabelNames: 1200, // Exceeds maxNumColumns to trigger sharding
+			labelsPerSeries:  200,  // Each series will have 200 unique labels (plus __name__)
+			minShards:        2,
+		},
+		{
+			name:             "without_numRowGroups_2_shards",
+			withNumRowGroups: false,
+			description:      "Uses singleTSDBRowReader path when numRowGroups is not set, creates 2 shards",
+			maxNumColumns:    1000, // 998 label columns + 2 system columns
+			uniqueLabelNames: 1200, // Exceeds maxNumColumns to trigger sharding
+			labelsPerSeries:  200,  // Each series will have 200 unique labels (plus __name__)
+			minShards:        2,
+		},
+		{
+			name:             "with_numRowGroups_3_shards",
+			withNumRowGroups: true,
+			description:      "Uses shardedTSDBRowReaders path when numRowGroups is set, creates 3+ shards",
+			maxNumColumns:    1000, // 998 label columns + 2 system columns
+			uniqueLabelNames: 2500, // Will require at least 3 shards (2500 / 998 ≈ 2.5)
+			labelsPerSeries:  300,  // Each series will have 300 unique labels (plus __name__)
+			minShards:        3,
+		},
+		{
+			name:             "without_numRowGroups_3_shards",
+			withNumRowGroups: false,
+			description:      "Uses singleTSDBRowReader path when numRowGroups is not set, creates 3+ shards",
+			maxNumColumns:    1000, // 998 label columns + 2 system columns
+			uniqueLabelNames: 2500, // Will require at least 3 shards (2500 / 998 ≈ 2.5)
+			labelsPerSeries:  300,  // Each series will have 300 unique labels (plus __name__)
+			minShards:        3,
+		},
+	}
+
+	for _, tt := range tc {
+		t.Run(tt.name, func(t *testing.T) {
+			bkt, err := filesystem.NewBucket(t.TempDir())
+			require.NoError(t, err)
+			t.Cleanup(func() { _ = bkt.Close() })
+
+			st, h, _ := createHighCardinalityTestData(t, tt.uniqueLabelNames, tt.labelsPerSeries)
+			t.Cleanup(func() { _ = st.Close() })
+
+			opts := []ConvertOption{
+				WithMaxNumColumns(tt.maxNumColumns),
+			}
+			if tt.withNumRowGroups {
+				opts = append(opts, WithNumRowGroups(4), WithRowGroupSize(1000))
+			}
+
+			shardCount, err := ConvertTSDBBlock(
+				ctx, bkt,
+				h.MinTime(), h.MaxTime(),
+				[]Convertible{h},
+				promslog.NewNopLogger(),
+				opts...,
+			)
+			require.NoError(t, err, "Conversion should succeed by creating multiple shards: %s", tt.description)
+			require.GreaterOrEqual(t, shardCount, tt.minShards, "Should create at least %d shards when exceeding column limit: %s", tt.minShards, tt.description)
+
+			// Verify each shard is valid and doesn't exceed the column limit
+			verifyShardsWithLimit(t, ctx, bkt, shardCount, tt.maxNumColumns)
+		})
+	}
+}
+
 func Test_WithBloomFilterLabels(t *testing.T) {
 	opts := DefaultConvertOpts
 

--- a/convert/convert_test.go
+++ b/convert/convert_test.go
@@ -904,36 +904,36 @@ func Test_TooManyColumns(t *testing.T) {
 			name:             "with_numRowGroups_2_shards",
 			withNumRowGroups: true,
 			description:      "Uses shardedTSDBRowReaders path when numRowGroups is set, creates 2 shards",
-			maxNumColumns:    100, // 98 label columns + 2 system columns
-			uniqueLabelNames: 150, // Exceeds maxNumColumns to trigger sharding
-			labelsPerSeries:  50,  // Each series will have 50 unique labels (plus __name__)
+			maxNumColumns:    20, // 18 label columns + 2 system columns
+			uniqueLabelNames: 30, // Exceeds maxNumColumns to trigger sharding
+			labelsPerSeries:  10, // Each series will have 10 unique labels (plus __name__)
 			minShards:        2,
 		},
 		{
 			name:             "without_numRowGroups_2_shards",
 			withNumRowGroups: false,
 			description:      "Uses singleTSDBRowReader path when numRowGroups is not set, creates 2 shards",
-			maxNumColumns:    100, // 98 label columns + 2 system columns
-			uniqueLabelNames: 150, // Exceeds maxNumColumns to trigger sharding
-			labelsPerSeries:  50,  // Each series will have 50 unique labels (plus __name__)
+			maxNumColumns:    20, // 18 label columns + 2 system columns
+			uniqueLabelNames: 30, // Exceeds maxNumColumns to trigger sharding
+			labelsPerSeries:  10, // Each series will have 10 unique labels (plus __name__)
 			minShards:        2,
 		},
 		{
 			name:             "with_numRowGroups_3_shards",
 			withNumRowGroups: true,
 			description:      "Uses shardedTSDBRowReaders path when numRowGroups is set, creates 3+ shards",
-			maxNumColumns:    100, // 98 label columns + 2 system columns
-			uniqueLabelNames: 250, // Will require at least 3 shards (250 / 98 ≈ 2.55)
-			labelsPerSeries:  80,  // Each series will have 80 unique labels (plus __name__)
+			maxNumColumns:    20, // 18 label columns + 2 system columns
+			uniqueLabelNames: 50, // Will require at least 3 shards (50 / 18 ≈ 2.78)
+			labelsPerSeries:  15, // Each series will have 15 unique labels (plus __name__)
 			minShards:        3,
 		},
 		{
 			name:             "without_numRowGroups_3_shards",
 			withNumRowGroups: false,
 			description:      "Uses singleTSDBRowReader path when numRowGroups is not set, creates 3+ shards",
-			maxNumColumns:    100, // 98 label columns + 2 system columns
-			uniqueLabelNames: 250, // Will require at least 3 shards (250 / 98 ≈ 2.55)
-			labelsPerSeries:  80,  // Each series will have 80 unique labels (plus __name__)
+			maxNumColumns:    20, // 18 label columns + 2 system columns
+			uniqueLabelNames: 50, // Will require at least 3 shards (50 / 18 ≈ 2.78)
+			labelsPerSeries:  15, // Each series will have 15 unique labels (plus __name__)
 			minShards:        3,
 		},
 	}


### PR DESCRIPTION
This PR introduces an automatic parquet file sharding based on the limit of number of columns in the generated parquet file. The parquet go library has a max limit of 32767 columns so this PR tries to shard based on that whenever number of columns would exceed the limit.

The implementation is using the same approach as https://github.com/thanos-io/thanos-parquet-gateway/pull/34 to use a map to keep track of number of labels and split whenever reaching limit.

It tries to handle both sharded reader and single reader path. We used to not shard at all in the single reader scenario but if it identifies that there are more label names than the configured limit, it tries to use the same code path to shard blocks.